### PR TITLE
Fixed bug in MaxStateChangesWithinMetric if given array with len=1

### DIFF
--- a/python/lsst/sims/maf/metrics/technicalMetrics.py
+++ b/python/lsst/sims/maf/metrics/technicalMetrics.py
@@ -109,6 +109,11 @@ class MaxStateChangesWithinMetric(BaseMetric):
                                                            metricName=metricName, units='#', **kwargs)
 
     def run(self, dataSlice, slicePoint=None):
+        # This operates slightly differently from the metrics above; those calculate only successive times
+        # between changes, but here we must calculate the actual times of each change. 
+        # Check if there was only one observation (and return 0 if so).
+        if dataSlice[self.changeCol].size == 1:
+            return 0
         # Sort on time, to be sure we've got filter (or other col) changes in the right order.
         idxs = np.argsort(dataSlice[self.timeCol])
         changes = (dataSlice[self.changeCol][idxs][1:] != dataSlice[self.changeCol][idxs][:-1])


### PR DESCRIPTION
Some nights in opsim actually had only one observation. (??). 
This made MaxStateChangesWithinMetric die (in typical use it measures the number of filter changes within 20 or 10 minutes). 
Added a check to see if given a len=1 array, and if so, return 0. 
Unit tests still pass.