### PR TITLE
Feature/sims 1129 run summary only sqlitefiles

### DIFF
--- a/python/lsst/sims/maf/db/opsimDatabase.py
+++ b/python/lsst/sims/maf/db/opsimDatabase.py
@@ -243,7 +243,7 @@ class OpsimDatabase(Database):
         """
         if 'Config' not in self.tables:
             print 'Cannot access Config table to retrieve site parameters; using utils.TelescopeInfo instead.'
-            site = utils.TelescopeInfo('LSST')
+            site = TelescopeInfo('LSST')
             lat = site.lat
             lon = site.lon
             height = site.elev

--- a/python/lsst/sims/maf/driver/mafDriver.py
+++ b/python/lsst/sims/maf/driver/mafDriver.py
@@ -26,7 +26,7 @@ class MafDriver(object):
         self.config = configvalues
         # Make sure only legitimate keys are in the dbAddress
         for key in self.config.dbAddress.keys():
-           if key not in ['dbAddress','dbClass']:
+           if key not in ['dbAddress','dbClass', 'Summary']:
               raise ValueError('key value "%s" not valid for dbAddress dict.  Must be "dbAddress" or "dbClass".'%key)
         # If a dbClass isn't specified, use OpsimDatabase
         if 'dbClass' not in self.config.dbAddress.keys():
@@ -49,7 +49,10 @@ class MafDriver(object):
         utils.moduleLoader(self.config.modules)
 
         # Set up database connection.
-        self.opsimdb = db.Database.getClass(self.config.dbAddress['dbClass'])(self.config.dbAddress['dbAddress'])
+        if 'Summary' in self.config.dbAddress:
+            self.opsimdb = utils.connectOpsimDb(self.config.dbAddress)
+        else:
+            self.opsimdb = db.Database.getClass(self.config.dbAddress['dbClass'])(self.config.dbAddress['dbAddress'])
 
         time_prev = time.time()
         self.time_start = time.time()

--- a/stdConfigs/schedulerValidation.py
+++ b/stdConfigs/schedulerValidation.py
@@ -6,7 +6,7 @@ import lsst.sims.maf.utils as utils
 import numpy as np
 
 
-def mConfig(config, runName, dbDir='.', outDir='Out', benchmark='design', summaryOnly=False, **kwargs):
+def mConfig(config, runName, dbDir='.', outDir='Out', benchmark='design', summaryOnly='False', slewStats='on', **kwargs):
     """
     A MAF config for SSTAR-like analysis of an opsim run.
 
@@ -21,9 +21,15 @@ def mConfig(config, runName, dbDir='.', outDir='Out', benchmark='design', summar
        ('requested' means look up the requested number of visits for the proposal and use that information).
     """
     #config.mafComment = 'Scheduler Validation'
+    if slewStats.lower() == 'off':
+        slewStats = False
+    else:
+        slewStats = True
 
-    if summaryOnly=='TRUE' or summaryOnly=='True':
+    if summaryOnly.lower() =='true':
         summaryOnly = True
+    else:
+        summaryOnly = False
 
     # Setup Database access
     config.outDir = outDir
@@ -869,7 +875,7 @@ def mConfig(config, runName, dbDir='.', outDir='Out', benchmark='design', summar
         slewStatsList.append(slicer)
 
     # Add the slew statistics back to the big metric/slicer list, if needed.
-    if not summaryOnly:
+    if not summaryOnly and slewStats:
         for slicer in slewStatsList:
             slicerList.append(slicer)
 

--- a/stdConfigs/schedulerValidation.py
+++ b/stdConfigs/schedulerValidation.py
@@ -746,6 +746,7 @@ def mConfig(config, runName, dbDir='.', outDir='Out', benchmark='design', summar
 
     # Stats for angle:
     angles = ['telAlt', 'telAz', 'rotTelPos']
+    slewStatsList = []
 
     order = 0
     for angle in angles:
@@ -769,9 +770,8 @@ def mConfig(config, runName, dbDir='.', outDir='Out', benchmark='design', summar
         metricDict = makeDict(*metricList)
         slicer = configureSlicer('UniSlicer', metricDict=metricDict, constraints=[''], metadata=angle,
                                  metadataVerbatim=True, table='SlewState')
-        slicerList.append(slicer)
+        slewStatsList.append(slicer)
 
-    slewStatsList = []
     # Make some calls to other tables to get slew stats
     colDict = {'domAltSpd':'Dome Alt Speed','domAzSpd':'Dome Az Speed','telAltSpd': 'Tel Alt Speed',
                'telAzSpd': 'Tel Az Speed', 'rotSpd':'Rotation Speed'}

--- a/stdConfigs/schedulerValidation.py
+++ b/stdConfigs/schedulerValidation.py
@@ -22,6 +22,9 @@ def mConfig(config, runName, dbDir='.', outDir='Out', benchmark='design', summar
     """
     #config.mafComment = 'Scheduler Validation'
 
+    if summaryOnly=='TRUE' or summaryOnly=='True':
+        summaryOnly = True
+
     # Setup Database access
     config.outDir = outDir
     if runName.endswith('_sqlite.db'):

--- a/stdConfigs/schedulerValidation.py
+++ b/stdConfigs/schedulerValidation.py
@@ -21,10 +21,12 @@ def mConfig(config, runName, dbDir='.', outDir='Out', benchmark='design', summar
        ('requested' means look up the requested number of visits for the proposal and use that information).
     """
     #config.mafComment = 'Scheduler Validation'
+    slewStats = True
+    slewStatsOnly = False
     if slewStats.lower() == 'off':
         slewStats = False
-    else:
-        slewStats = True
+    elif slewStats.lower() == 'only':
+        slewStatsOnly = True
 
     if summaryOnly.lower() =='true':
         summaryOnly = True
@@ -876,8 +878,14 @@ def mConfig(config, runName, dbDir='.', outDir='Out', benchmark='design', summar
 
     # Add the slew statistics back to the big metric/slicer list, if needed.
     if not summaryOnly and slewStats:
-        for slicer in slewStatsList:
-            slicerList.append(slicer)
+        if slewStatsOnly:
+            # Return the slewStats slicer list only, if only doing slew stats.
+            config.slicers=makeDict(*slewStatsList)
+            return config
+        else:
+            # Else, add the slew stats to the general list, which will be returned later.
+            for slicer in slewStatsList:
+                slicerList.append(slicer)
 
     # Count the number of visits per proposal, for all proposals, as well as the ratio of number of visits
     #  for each proposal compared to total number of visits.

--- a/stdConfigs/schedulerValidation.py
+++ b/stdConfigs/schedulerValidation.py
@@ -21,17 +21,17 @@ def mConfig(config, runName, dbDir='.', outDir='Out', benchmark='design', summar
        ('requested' means look up the requested number of visits for the proposal and use that information).
     """
     #config.mafComment = 'Scheduler Validation'
-    slewStats = True
-    slewStatsOnly = False
+    slewStatsFlag = True
+    slewStatsOnlyFlag = False
     if slewStats.lower() == 'off':
-        slewStats = False
+        slewStatsFlag = False
     elif slewStats.lower() == 'only':
-        slewStatsOnly = True
+        slewStatsOnlyFlag = True
 
     if summaryOnly.lower() =='true':
-        summaryOnly = True
+        summaryOnlyFlag = True
     else:
-        summaryOnly = False
+        summaryOnlyFlag = False
 
     # Setup Database access
     config.outDir = outDir
@@ -39,7 +39,7 @@ def mConfig(config, runName, dbDir='.', outDir='Out', benchmark='design', summar
         runName = runName.replace('_sqlite.db', '')
     sqlitefile = os.path.join(dbDir, runName + '_sqlite.db')
     config.dbAddress ={'dbAddress':'sqlite:///'+sqlitefile}
-    if summaryOnly:
+    if summaryOnlyFlag:
         config.dbAddress['Summary'] = 'Summary'
     config.opsimName = runName
     config.figformat = 'pdf'
@@ -877,8 +877,8 @@ def mConfig(config, runName, dbDir='.', outDir='Out', benchmark='design', summar
         slewStatsList.append(slicer)
 
     # Add the slew statistics back to the big metric/slicer list, if needed.
-    if not summaryOnly and slewStats:
-        if slewStatsOnly:
+    if not summaryOnlyFlag and slewStatsFlag:
+        if slewStatsOnlyFlag:
             # Return the slewStats slicer list only, if only doing slew stats.
             config.slicers=makeDict(*slewStatsList)
             return config

--- a/stdConfigs/sciencePerformance.py
+++ b/stdConfigs/sciencePerformance.py
@@ -8,7 +8,7 @@ import lsst.sims.maf.utils as utils
 
 
 def mConfig(config, runName, dbDir='.', outDir='ScienceOut', nside=128, raCol='fieldRA', decCol='fieldDec',
-             benchmark='design', **kwargs):
+             benchmark='design', summaryOnly=False, **kwargs):
     """
     A MAF config for SSTAR-like analysis of an opsim run.
 
@@ -24,12 +24,17 @@ def mConfig(config, runName, dbDir='.', outDir='ScienceOut', nside=128, raCol='f
     """
     #config.mafComment = 'Science Performance'
 
+    if summaryOnly=='TRUE' or summaryOnly=='True':
+        summaryOnly = True
+
     # Setup Database access
     config.outDir = outDir
     if runName.endswith('_sqlite.db'):
         runName = runName.replace('_sqlite.db', '')
     sqlitefile = os.path.join(dbDir, runName + '_sqlite.db')
     config.dbAddress ={'dbAddress':'sqlite:///'+sqlitefile}
+    if summaryOnly:
+        config.dbAddress['Summary'] = 'Summary'
     config.opsimName = runName
     config.figformat = 'pdf'
 


### PR DESCRIPTION
This branch lets the user run fairly seamlessly on summary table only sqlite files. This probably won't come in handy tooo often, but I did use it to run on opsim3_61 (after converting the old .dat file to new format sqlite summary table). 
I also put the slew stat options in here too ('all' / 'only' / 'off' -- default being to just run them, and you'd have to know the other keywords specifically to turn them off). 