### PR TITLE
feature/SIM-1103/rewrite_obs_metadata

### DIFF
--- a/examples/pythonScripts/checkChips.py
+++ b/examples/pythonScripts/checkChips.py
@@ -11,7 +11,7 @@ camera = mapper.camera
 epoch = 2000.0
 
 # Generate a dummy obs_metadata:
-obs_metadata = ObservationMetaData(m5=0.)
+obs_metadata = ObservationMetaData(m5=0., bandpassName='g')
 obs_metadata.unrefractedRA = np.pi/2.
 obs_metadata.unrefractedDec = 0.
 obs_metadata.rotSkyPos = 0.

--- a/python/lsst/sims/maf/slicers/baseSpatialSlicer.py
+++ b/python/lsst/sims/maf/slicers/baseSpatialSlicer.py
@@ -109,7 +109,7 @@ class BaseSpatialSlicer(BaseSlicer):
         self.camera = mapper.camera
         self.myCamCoords = CameraCoords()
         self.epoch = 2000.0
-        self.obs_metadata = ObservationMetaData(m5=0.)
+        self.obs_metadata = ObservationMetaData(m5=0., bandpassName='g')
 
     def _presliceFootprint(self, simData):
         """Loop over each pointing and find which sky points are observed """


### PR DESCRIPTION
I am overhauling the ObservationMetaData class to make it safe for people to change on the fly, i.e.

obs = ObservationMetaData(unrefractedRA=25, unrefractedDec=15)
...
obs.unrefractedRA=11

etc.

Part of this is that you can no longer specify an m5 without also specifying a bandpassName.  That required a few minor changes in MAF to get things to run.  Does this API seem okay to you, or would you rather have m5 remain divorced of bandpass?