### PR TITLE
Feature/sim 1221 healpix ps maxl

### DIFF
--- a/python/lsst/sims/maf/metricBundles/metricBundle.py
+++ b/python/lsst/sims/maf/metricBundles/metricBundle.py
@@ -219,7 +219,7 @@ class MetricBundle(object):
                 self.plotFuncs = []
                 for pFunc in plotFuncs:
                     if not isinstance(pFunc, plots.BasePlotter):
-                        raise ValueError('plotFuncs should contain lsst.sims.maf.plotter objects.')
+                        raise ValueError('plotFuncs should contain instantiated lsst.sims.maf.plotter objects.')
                     self.plotFuncs.append(pFunc)
         else:
             self.plotFuncs = [pFunc() for pFunc in self.slicer.plotFuncs]

--- a/python/lsst/sims/maf/plots/spatialPlotters.py
+++ b/python/lsst/sims/maf/plots/spatialPlotters.py
@@ -116,7 +116,7 @@ class HealpixPowerSpectrum(BasePlotter):
         self.plotType = 'PowerSpectrum'
         self.objectPlotter = False
         self.defaultPlotDict = {'title':None, 'label':None,
-                                'maxl':500., 'removeDipole':True,
+                                'maxl':None, 'removeDipole':True,
                                 'logScale':True}
 
     def __call__(self, metricValue, slicer, userPlotDict, fignum=None):
@@ -134,15 +134,15 @@ class HealpixPowerSpectrum(BasePlotter):
         if False not in metricValue.mask:
             return None
         if plotDict['removeDipole']:
-            cl = hp.anafast(hp.remove_dipole(metricValue.filled(slicer.badval)))
+            cl = hp.anafast(hp.remove_dipole(metricValue.filled(slicer.badval)), lmax=plotDict['maxl'])
         else:
-            cl = hp.anafast(metricValue.filled(slicer.badval))
+            cl = hp.anafast(metricValue.filled(slicer.badval), lmax=plotDict['maxl'])
         l = np.arange(np.size(cl))
         # Plot the results.
         if plotDict['removeDipole']:
-            condition = ((l < plotDict['maxl']) & (l > 1))
+            condition = (l > 1)
         else:
-            condition = (l < plotDict['maxl'])
+            condition = (l >= 0)
         plt.plot(l[condition], (cl[condition]*l[condition]*(l[condition]+1))/2.0/np.pi, label=plotDict['label'])
         if cl[condition].max() > 0 and plotDict['logScale']:
             plt.yscale('log')

--- a/python/lsst/sims/maf/plots/spatialPlotters.py
+++ b/python/lsst/sims/maf/plots/spatialPlotters.py
@@ -19,17 +19,6 @@ from lsst.sims.utils import equatorialFromGalactic
 __all__ = ['HealpixSkyMap', 'HealpixPowerSpectrum', 'HealpixHistogram', 'OpsimHistogram',
            'BaseHistogram', 'BaseSkyMap', 'HealpixSDSSSkyMap']
 
-class BasePlotter(object):
-    """
-    Serve as the base type for MAF plotters and example of API.
-    """
-    def __init__(self):
-        self.plotType = None
-        self.objectPlotter = False
-        self.defaultPlotDict = None
-
-    def __call__(self, metricValue, slicer, userPlotDict, fignum=None):
-        pass
 
 class HealpixSkyMap(BasePlotter):
     def __init__(self):

--- a/python/lsst/sims/maf/plots/spatialPlotters.py
+++ b/python/lsst/sims/maf/plots/spatialPlotters.py
@@ -137,13 +137,13 @@ class HealpixPowerSpectrum(BasePlotter):
             cl = hp.anafast(hp.remove_dipole(metricValue.filled(slicer.badval)), lmax=plotDict['maxl'])
         else:
             cl = hp.anafast(metricValue.filled(slicer.badval), lmax=plotDict['maxl'])
-        l = np.arange(np.size(cl))
+        ell = np.arange(np.size(cl))
         # Plot the results.
         if plotDict['removeDipole']:
-            condition = (l > 1)
+            condition = (ell > 1)
         else:
-            condition = (l >= 0)
-        plt.plot(l[condition], (cl[condition]*l[condition]*(l[condition]+1))/2.0/np.pi, label=plotDict['label'])
+            condition = (ell >= 0)
+        plt.plot(ell[condition], (cl[condition]*ell[condition]*(ell[condition]+1))/2.0/np.pi, label=plotDict['label'])
         if cl[condition].max() > 0 and plotDict['logScale']:
             plt.yscale('log')
         plt.xlabel(r'$l$')

--- a/python/lsst/sims/maf/plots/spatialPlotters.py
+++ b/python/lsst/sims/maf/plots/spatialPlotters.py
@@ -138,13 +138,15 @@ class HealpixPowerSpectrum(BasePlotter):
         else:
             cl = hp.anafast(metricValue.filled(slicer.badval), lmax=plotDict['maxl'])
         ell = np.arange(np.size(cl))
-        # Plot the results.
         if plotDict['removeDipole']:
             condition = (ell > 1)
         else:
-            condition = (ell >= 0)
-        plt.plot(ell[condition], (cl[condition]*ell[condition]*(ell[condition]+1))/2.0/np.pi, label=plotDict['label'])
-        if cl[condition].max() > 0 and plotDict['logScale']:
+            condition = (ell > 0)
+        ell = ell[condition]
+        cl = cl[condition]
+        # Plot the results.
+        plt.plot(ell, (cl*ell*(ell+1))/2.0/np.pi, label=plotDict['label'])
+        if cl.max() > 0 and plotDict['logScale']:
             plt.yscale('log')
         plt.xlabel(r'$l$')
         plt.ylabel(r'$l(l+1)C_l/(2\pi)$')


### PR DESCRIPTION
Small PR related to changing how we access healpy's anafast to calculate the power spectrum. 
Previously, we let the user set 'maxl', the maximum l value that they wanted to calculate the power spectrum out to. However, healpy.anafast also has a built-in cutoff default value, so if someone specified a maxl larger than 3*nside-1, their 'maxl' would be ignored. 
healpy.anafast documentation: 
http://healpy.readthedocs.org/en/latest/generated/healpy.sphtfunc.anafast.html

Now we handle the 'maxl' specification more appropriately, by passing this value directly to anafast. 