### PR TITLE
Bugfix/sim 1229 stackers with no data

### DIFF
--- a/python/lsst/sims/maf/metricBundles/metricBundleGroup.py
+++ b/python/lsst/sims/maf/metricBundles/metricBundleGroup.py
@@ -95,6 +95,7 @@ class MetricBundleGroup(object):
             print "Querying database with constraint %s" % self.sqlconstraint
         # Note that we do NOT run the stackers at this point (this must be done in each 'compatible' group).
         self.simData = utils.getSimData(self.dbObj, self.sqlconstraint, self.dbCols)
+
         if self.verbose:
             print "Found %i visits" % self.simData.size
 
@@ -175,7 +176,15 @@ class MetricBundleGroup(object):
         Also runs 'reduceAll' and then 'summaryAll'.
         """
         if self.simData is None:
-            self.getData()
+            try:
+                self.getData()
+            except UserWarning:
+                print 'No data matching sqlconstraint %s' %(self.sqlconstraint)
+                return
+            except ValueError:
+                print 'One of the columns requested from the database was not available - skipping sqlconstraint %s' %(self.sqlconstraint)
+                return
+
         for compatibleList in self.compatibleLists:
             if self.verbose:
                 print 'Running: ', compatibleList
@@ -197,6 +206,10 @@ class MetricBundleGroup(object):
         """
         Runs a set of 'compatible' metricbundles in the MetricBundleGroup dictionary, identified by 'compatibleList' keys.
         """
+
+        if len(self.simData) == 0:
+            return
+
         # Grab a dictionary representation of this subset of the dictionary, for easier iteration.
         bDict = self._getDictSubset(self.bundleDict, compatibleList)
 
@@ -209,11 +222,14 @@ class MetricBundleGroup(object):
                 if stacker not in compatStackers:
                     compatStackers.append(stacker)
 
-        # May need to do a more rigorous purge of duplicate stackers and maps
+        # Add maps.
+        # May need to do a more rigorous purge of duplicate maps
         compatMaps = list(set(compatMaps))
 
+        # Run stackers.
+        # Note that we've already checked that stackers do not re-create the same columns with different values
         for stacker in compatStackers:
-            # Check that stackers can clobber cols that are already there
+            # Note that stackers will clobber previously existing rows with the same name.
             self.simData = stacker.run(self.simData)
 
         # Pull out one of the slicers to use as our 'slicer'.

--- a/python/lsst/sims/maf/stackers/generalStackers.py
+++ b/python/lsst/sims/maf/stackers/generalStackers.py
@@ -1,6 +1,8 @@
-import numpy as np
-from .baseStacker import BaseStacker
 import warnings
+import numpy as np
+import palpy
+
+from .baseStacker import BaseStacker
 
 __all__ = ['NormAirmassStacker', 'ParallaxFactorStacker', 'HourAngleStacker',
             'FilterColorStacker']
@@ -76,7 +78,6 @@ class ParallaxFactorStacker(BaseStacker):
         return x, y
 
     def run(self, simData):
-        import palpy
         ra_pi_amp = np.zeros(np.size(simData), dtype=[('ra_pi_amp','float')])
         dec_pi_amp = np.zeros(np.size(simData), dtype=[('dec_pi_amp','float')])
         ra_geo1 = np.zeros(np.size(simData), dtype='float')
@@ -111,6 +112,8 @@ class HourAngleStacker(BaseStacker):
 
     def run(self, simData):
         """HA = LST - RA """
+        if len(simData) == 0:
+            return simData
         # Check that LST is reasonable
         if (np.min(simData[self.lstCol]) < 0) | (np.max(simData[self.lstCol]) > 2.*np.pi):
             warnings.warn('LST values are not between 0 and 2 pi')

--- a/python/lsst/sims/maf/utils/opsimUtils.py
+++ b/python/lsst/sims/maf/utils/opsimUtils.py
@@ -97,13 +97,13 @@ def getFieldData(opsimDb, sqlconstraint):
 
 def getSimData(opsimDb, sqlconstraint, dbcols, stackers=None):
     """
-    Query the opsim database for the necessary simdata columns, run any needed stackers,
+    Query the database for the necessary simdata columns, run any needed stackers,
     return simdata array.
     """
     # Get data from database.
     simData = opsimDb.fetchMetricData(dbcols, sqlconstraint)
     if len(simData) == 0:
-        raise Exception('No simdata found matching constraint %s' %(sqlconstraint))
+        raise UserWarning('No data found matching sqlconstraint %s' %(sqlconstraint))
     # Now add the stacker columns.
     if stackers is not None:
         for s in stackers:


### PR DESCRIPTION
Handle cases where there is no data to retrieve from the database. 

Now skip running the associated metrics/stackers in the 'metricBundleGroup'. 
But also updated the HA stacker to skip cases with  no data, just in case. 