### PR TITLE
Feature/add chipname to slicepoint

### DIFF
--- a/python/lsst/sims/maf/metricBundles/metricBundleGroup.py
+++ b/python/lsst/sims/maf/metricBundles/metricBundleGroup.py
@@ -334,6 +334,7 @@ class MetricBundleGroup(object):
                             b.metricValues.data[i] = b.metricValues.data[cacheDict[cacheKey]]
                         else:
                             b.metricValues.data[i] = b.metric.run(slicedata, slicePoint=slice_i['slicePoint'])
+
                 # Not using memoize, just calculate things normally
                 else:
                     for b in bDict.itervalues():

--- a/python/lsst/sims/maf/metrics/__init__.py
+++ b/python/lsst/sims/maf/metrics/__init__.py
@@ -13,3 +13,4 @@ from .longGapAGNMetric import *
 from .exgalM5 import *
 from .slewMetrics import *
 from .transientMetrics import *
+from .chipVendorMetric import *

--- a/python/lsst/sims/maf/metrics/chipVendorMetric.py
+++ b/python/lsst/sims/maf/metrics/chipVendorMetric.py
@@ -1,0 +1,39 @@
+import numpy as np
+from .baseMetric import BaseMetric
+
+__all__ = ['ChipVendorMetric']
+
+class ChipVendorMetric(BaseMetric):
+    """
+    See what happens if we have chips from different vendors
+    """
+
+    def __init__(self, cols=None, **kwargs):
+        if cols is None:
+            cols = []
+        super(ChipVendorMetric,self)_.__init__(cols=cols, metricDtyep=int, **kwargs)
+
+    def _chipNames2vendorID(chipName):
+        """
+        given a list of chipnames, convert to 1 or 2, representing
+        different vendors
+        """
+        vendors=[]
+        for chip in chipName:
+            if int(chip[2]) % 2 == 0:
+                vendors.append(0):
+            else:
+                vendors.append(1)
+        return vendors
+
+    def run(dataSlice, slicePoint=None):
+
+        if 'chipNames' not in slicePoint.keys:
+            raise ValueError('No chipname info, need to set useCamera=True with a spatial slicer.')
+
+        uvendorIDs = np.unique(_chipNames2vendorID(slicePoint['chipNames']))
+        if np.size(uvendorIDs) == 1:
+            result = uvendorIDs
+        else:
+            result = 3
+        return result

--- a/python/lsst/sims/maf/metrics/chipVendorMetric.py
+++ b/python/lsst/sims/maf/metrics/chipVendorMetric.py
@@ -11,27 +11,29 @@ class ChipVendorMetric(BaseMetric):
     def __init__(self, cols=None, **kwargs):
         if cols is None:
             cols = []
-        super(ChipVendorMetric,self)_.__init__(cols=cols, metricDtyep=int, **kwargs)
+        super(ChipVendorMetric,self).__init__(col=cols, metricDtype=float,
+                                              units='1,2,3:v1,v2,both', **kwargs)
 
-    def _chipNames2vendorID(chipName):
+    def _chipNames2vendorID(self, chipName):
         """
         given a list of chipnames, convert to 1 or 2, representing
         different vendors
         """
         vendors=[]
         for chip in chipName:
+            # Parse the chipName string.
             if int(chip[2]) % 2 == 0:
-                vendors.append(0):
-            else:
                 vendors.append(1)
+            else:
+                vendors.append(2)
         return vendors
 
-    def run(dataSlice, slicePoint=None):
+    def run(self, dataSlice, slicePoint=None):
 
-        if 'chipNames' not in slicePoint.keys:
+        if 'chipNames' not in slicePoint.keys():
             raise ValueError('No chipname info, need to set useCamera=True with a spatial slicer.')
 
-        uvendorIDs = np.unique(_chipNames2vendorID(slicePoint['chipNames']))
+        uvendorIDs = np.unique(self._chipNames2vendorID(slicePoint['chipNames']))
         if np.size(uvendorIDs) == 1:
             result = uvendorIDs
         else:

--- a/python/lsst/sims/maf/slicers/baseSpatialSlicer.py
+++ b/python/lsst/sims/maf/slicers/baseSpatialSlicer.py
@@ -93,10 +93,8 @@ class BaseSpatialSlicer(BaseSlicer):
                 sx, sy, sz = self._treexyz(self.slicePoints['ra'][islice], self.slicePoints['dec'][islice])
                 # Query against tree.
                 indices = self.opsimtree.query_ball_point((sx, sy, sz), self.rad)
-                self.chipNames = None
 
             for key in self.slicePoints.keys():
-                # If we have used the _presliceFootprint to
                 if np.size(self.slicePoints[key]) > 1:
                     slicePoint[key] = self.slicePoints[key][islice]
                 else:
@@ -142,9 +140,9 @@ class BaseSpatialSlicer(BaseSlicer):
                 # Find the healpixels that fell on a chip for this pointing
                 good = np.where(chipNames != [None])[0]
                 hpOnChip = hpIndices[good]
-                for i in hpOnChip:
+                for i,chipName in zip(hpOnChip,chipNames[good]):
                     self.sliceLookup[i].append(ind)
-                    self.chipNames[i].append(chipNames[good])
+                    self.chipNames[i].append(chipName)
 
         if self.verbose:
             "Created lookup table after checking for chip gaps."

--- a/python/lsst/sims/maf/slicers/healpixSlicer.py
+++ b/python/lsst/sims/maf/slicers/healpixSlicer.py
@@ -20,13 +20,13 @@ class HealpixSlicer(BaseSpatialSlicer):
     """Healpix spatial slicer."""
     def __init__(self, nside=128, lonCol ='fieldRA' , latCol='fieldDec', verbose=True,
                  useCache=True, radius=1.75, leafsize=100,
-                 useCamera=False, rotSkyPosColName='rotSkyPos', mjdColName='expMJD'):
+                 useCamera=False, rotSkyPosColName='rotSkyPos', mjdColName='expMJD', **kwargs):
         """Instantiate and set up healpix slicer object."""
         super(HealpixSlicer, self).__init__(verbose=verbose,
                                             lonCol=lonCol, latCol=latCol,
                                             badval=hp.UNSEEN, radius=radius, leafsize=leafsize,
                                             useCamera=useCamera, rotSkyPosColName=rotSkyPosColName,
-                                            mjdColName=mjdColName)
+                                            mjdColName=mjdColName, **kwargs)
         # Valid values of nside are powers of 2.
         # nside=64 gives about 1 deg resolution
         # nside=256 gives about 13' resolution (~1 CCD)

--- a/python/lsst/sims/maf/slicers/healpixSlicer.py
+++ b/python/lsst/sims/maf/slicers/healpixSlicer.py
@@ -20,13 +20,13 @@ class HealpixSlicer(BaseSpatialSlicer):
     """Healpix spatial slicer."""
     def __init__(self, nside=128, lonCol ='fieldRA' , latCol='fieldDec', verbose=True,
                  useCache=True, radius=1.75, leafsize=100,
-                 useCamera=False, rotSkyPosColName='rotSkyPos', mjdColName='expMJD', **kwargs):
+                 useCamera=False, chipNames='all', rotSkyPosColName='rotSkyPos', mjdColName='expMJD'):
         """Instantiate and set up healpix slicer object."""
         super(HealpixSlicer, self).__init__(verbose=verbose,
                                             lonCol=lonCol, latCol=latCol,
                                             badval=hp.UNSEEN, radius=radius, leafsize=leafsize,
                                             useCamera=useCamera, rotSkyPosColName=rotSkyPosColName,
-                                            mjdColName=mjdColName, **kwargs)
+                                            mjdColName=mjdColName, chipNames=chipNames)
         # Valid values of nside are powers of 2.
         # nside=64 gives about 1 deg resolution
         # nside=256 gives about 13' resolution (~1 CCD)

--- a/tests/testHealpixSlicer.py
+++ b/tests/testHealpixSlicer.py
@@ -193,7 +193,8 @@ class TestHealpixChipGap(unittest.TestCase):
         self.radius = 2.041
         self.testslicer = HealpixSlicer(nside=self.nside, verbose=False,
                                         lonCol='ra', latCol='dec',
-                                        radius=self.radius, useCamera=True)
+                                        radius=self.radius, useCamera=True,
+                                        chipNames=['R:1,1 S:1,1'])
         nvalues = 1000
         self.dv = makeDataValues(size=nvalues, minval=0., maxval=1.,
                                 ramin=0, ramax=2*np.pi,


### PR DESCRIPTION
When using the camera geometry, make it possible to select a subset of raft+chips with the slicer. Also pass the raft+chip info with slicePoint so metrics can compute stats on chips.