### PR TITLE
reduce memory footprint of sciencePerformance and other bug fixes

### DIFF
--- a/python/lsst/sims/maf/metricBundles/metricBundleGroup.py
+++ b/python/lsst/sims/maf/metricBundles/metricBundleGroup.py
@@ -159,14 +159,11 @@ class MetricBundleGroup(object):
             # Set the 'currentBundleDict' which is a dictionary of the metricBundles which match this
             #  sqlconstraint.
             self.setCurrent(sqlconstraint)
-            self.runCurrent(sqlconstraint, clearMemory=clearMemory)
-            if plotNow:
-                if plotKwargs is None:
-                    self.plotCurrent()
-                else:
-                    self.plotCurrent(**plotKwargs)
+            self.runCurrent(sqlconstraint, clearMemory=clearMemory,
+                            plotNow=plotNow,plotKwargs=plotKwargs)
 
-    def runCurrent(self, sqlconstraint, clearMemory=False, simData=None):
+
+    def runCurrent(self, sqlconstraint, clearMemory=False, simData=None, plotNow=False, plotKwargs=None):
         """
         Run all the metricBundles which match this sqlconstraint in the metricBundleGroup.
         Also runs 'reduceAll' and then 'summaryAll'.
@@ -196,7 +193,6 @@ class MetricBundleGroup(object):
         # Find compatible subsets of the MetricBundle dictionary, which can be run/metrics calculated/ together.
         self._findCompatibleLists()
 
-
         for compatibleList in self.compatibleLists:
             if self.verbose:
                 print 'Running: ', compatibleList
@@ -215,6 +211,11 @@ class MetricBundleGroup(object):
         self.summaryCurrent()
         if self.verbose:
             print 'Completed.'
+        if plotNow:
+            if plotKwargs is None:
+                self.plotCurrent()
+            else:
+                self.plotCurrent(**plotKwargs)
         # Optionally: clear results from memory.
         if clearMemory:
             for b in self.currentBundleDict.itervalues():

--- a/python/lsst/sims/maf/metrics/vectorMetrics.py
+++ b/python/lsst/sims/maf/metrics/vectorMetrics.py
@@ -133,7 +133,7 @@ class AccumulateUniformityMetric(AccumulateMetric):
 
         visitsPerNight, blah = np.histogram(dataSlice[self.binCol], bins=self.bins)
         visitsPerNight = np.add.accumulate(visitsPerNight)
-        expectedPerNight = np.arange(0,self.bins.max())/self.bins.max() * dataSlice.size
+        expectedPerNight = np.arange(0.,self.bins.size-1)/(self.bins.size-2) * dataSlice.size
 
         D_max = np.abs(visitsPerNight-expectedPerNight)
         D_max = np.maximum.accumulate(D_max)

--- a/python/lsst/sims/maf/plots/twoDPlotters.py
+++ b/python/lsst/sims/maf/plots/twoDPlotters.py
@@ -58,9 +58,12 @@ class TwoDMap(BasePlotter):
         ax = figure.add_subplot(111)
         yextent = slicer.spatialExtent
         xextent = plotDict['xextent']
+        extent = []
+        extent.extend(xextent)
+        extent.extend(yextent)
         image = ax.imshow(metricValue, vmin=plotDict['colorMin'], vmax=plotDict['colorMax'],
                           aspect=plotDict['aspect'], cmap=plotDict['cmap'], norm=norm,
-                          extent=xextent.extend(yextent),
+                          extent=extent,
                           interpolation='none',origin=plotDict['origin'])
         cb =  plt.colorbar(image)
 


### PR DESCRIPTION
Reduce the memory footprint of science performance by about an order of magnitude.
Stop sciencePerformance.py from writing out the largest files
Make it possible to make plots without saving the metric values
Fix the x-axis labels when binsize is != 1 on the twoD plotter.