### PR TITLE
Updated maf tracking database to also keep a link for the sqlite data…

### DIFF
--- a/bin.src/addRun.py
+++ b/bin.src/addRun.py
@@ -14,6 +14,7 @@ if __name__ == "__main__":
     parser.add_argument("--opsimComment", type=str, default=None, help="Comment on OpSim run.")
     parser.add_argument("--opsimDate", type=str, default=None, help="Date Opsim was run")
     parser.add_argument("--mafDate", type=str, default=None, help="Date MAF was run")
+    parser.add_argument("--dbFile", type=str, default=None, help="Opsim Sqlite filename")
     defaultdb = 'trackingDb_sqlite.db'
     parser.add_argument("-t", "--trackingDb", type=str, default=defaultdb, help="Tracking database filename.")
     args = parser.parse_args()
@@ -31,6 +32,7 @@ if __name__ == "__main__":
     opsimComment = args.opsimComment
     opsimDate = args.opsimDate
     mafDate = args.mafDate
+    dbFile = os.path.realpath(args.dbFile)
     if (opsimRun is None) or (opsimComment is None) or (opsimDate is None) or (mafDate is None):
         if os.path.isfile(os.path.join(mafDir, 'configSummary.txt')):
             file = open(os.path.join(mafDir, 'configSummary.txt'))
@@ -59,5 +61,6 @@ if __name__ == "__main__":
     print ' OpsimComment = %s' % (opsimComment)
     print ' OpsimDate = %s' % (opsimDate)
     print ' MafDate = %s' % (mafDate)
+    print ' DbFile = %s' % (dbFile)
 
-    trackingDb.addRun(opsimRun, opsimComment, args.mafComment, mafDir, opsimDate, mafDate)
+    trackingDb.addRun(opsimRun, opsimComment, args.mafComment, mafDir, opsimDate, mafDate, dbFile)

--- a/bin.src/addRun.py
+++ b/bin.src/addRun.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
     parser.add_argument("-t", "--trackingDb", type=str, default=defaultdb, help="Tracking database filename.")
     args = parser.parse_args()
 
-    mafDir = os.path.realpath(args.mafDir)
+    mafDir = os.path.abspath(args.mafDir)
     if not os.path.isdir(mafDir):
         print 'There is no directory containing MAF outputs at %s.' % (mafDir)
         print 'Exiting.'
@@ -32,7 +32,7 @@ if __name__ == "__main__":
     opsimComment = args.opsimComment
     opsimDate = args.opsimDate
     mafDate = args.mafDate
-    dbFile = os.path.realpath(args.dbFile)
+    dbFile = os.path.abspath(args.dbFile)
     if (opsimRun is None) or (opsimComment is None) or (opsimDate is None) or (mafDate is None):
         if os.path.isfile(os.path.join(mafDir, 'configSummary.txt')):
             file = open(os.path.join(mafDir, 'configSummary.txt'))

--- a/python/lsst/sims/maf/db/trackingDb.py
+++ b/python/lsst/sims/maf/db/trackingDb.py
@@ -11,6 +11,7 @@ Base = declarative_base()
 
 __all__ = ['TrackingDb']
 
+
 class RunRow(Base):
     """
     Define contents and format of run list table.
@@ -26,9 +27,12 @@ class RunRow(Base):
     mafDir = Column(String)
     opsimDate = Column(String)
     mafDate = Column(String)
+    dbFile = Column(String)
     def __repr__(self):
-        return "<Run(mafRunId='%d', opsimRun='%s', opsimComment='%s', mafComment='%s', mafDir='%s', opsimDate='%s', mafDate='%s'>" \
-            %(self.mafRunId, self.opsimRun, self.opsimComment, self.mafComment, self.mafDir, self.opsimDate, self.mafDate)
+        rstr = "<Run(mafRunId='%d', opsimRun='%s', opsimComment='%s', mafComment='%s', " % (self.mafRunId, self.opsimRun,
+                                                                                          self.opsimComment, self.mafComment)
+        rstr += "mafDir='%s', opsimDate='%s', mafDate='%s', dbFile='%s'>" %(self.mafDir, self.opsimDate, self.mafDate, self.dbFile)
+        return rstr
 
 
 class TrackingDb(object):
@@ -75,7 +79,7 @@ class TrackingDb(object):
     def close(self):
         self.session.close()
 
-    def addRun(self, opsimRun, opsimComment, mafComment, mafDir, opsimDate, mafDate, override=False):
+    def addRun(self, opsimRun, opsimComment, mafComment, mafDir, opsimDate, mafDate, dbFile, override=False):
         """
         Add a run to the tracking database.
         """
@@ -89,6 +93,8 @@ class TrackingDb(object):
             opsimDate = 'NULL'
         if mafDate is None:
             mafDate = 'NULL'
+        if dbFile is None:
+            dbFile = 'NULL'
         # Test if mafDir already exists in database (unless directed not to check via override).
         if not override:
             prevruns = self.session.query(RunRow).filter_by(mafDir=mafDir).all()
@@ -101,7 +107,7 @@ class TrackingDb(object):
                 return runIds[0]
         # Run did not exist in database or we received override: add it.
         runinfo = RunRow(opsimRun=opsimRun, opsimComment=opsimComment, mafComment=mafComment,
-                         mafDir=mafDir, opsimDate=opsimDate, mafDate=mafDate)
+                         mafDir=mafDir, opsimDate=opsimDate, mafDate=mafDate, dbFile=dbFile)
         self.session.add(runinfo)
         self.session.commit()
         return runinfo.mafRunId

--- a/python/lsst/sims/maf/viz/mafRunResults.py
+++ b/python/lsst/sims/maf/viz/mafRunResults.py
@@ -134,6 +134,8 @@ class MafRunResults(object):
     def getResultsDb(self):
         """
         Return the summary results sqlite filename.
+
+        Note that this assumes the resultsDB is stored in 'resultsDB_sqlite.db'.
         """
         return os.path.join(self.outDir, 'resultsDb_sqlite.db')
 

--- a/python/lsst/sims/maf/viz/mafTracking.py
+++ b/python/lsst/sims/maf/viz/mafTracking.py
@@ -50,9 +50,9 @@ class MafTracking(object):
         runInfo['OpsimRun'] = run['opsimRun']
         runInfo['MafComment'] = run['mafComment']
         runInfo['OpsimComment'] = run['opsimComment']
-        runInfo['SQLite File'] = [run['dbFile'], os.path.split(run['dbFile'])[1]]
+        runInfo['SQLite File'] = [os.path.relpath(run['dbFile']), os.path.split(run['dbFile'])[1]]
         runInfo['MafDir'] = run['mafDir']
-        runInfo['ResultsDb'] = os.path.join(run['mafDir'], 'resultsDb_sqlite.db')
+        runInfo['ResultsDb'] = os.path.relpath(os.path.join(run['mafDir'], 'resultsDb_sqlite.db'))
         runInfo['OpsimDate'] = run['opsimDate']
         runInfo['MafDate'] = run['mafDate']
         return runInfo

--- a/python/lsst/sims/maf/viz/mafTracking.py
+++ b/python/lsst/sims/maf/viz/mafTracking.py
@@ -50,7 +50,9 @@ class MafTracking(object):
         runInfo['OpsimRun'] = run['opsimRun']
         runInfo['MafComment'] = run['mafComment']
         runInfo['OpsimComment'] = run['opsimComment']
+        runInfo['SQLite File'] = [run['dbFile'], os.path.split(run['dbFile'])[1]]
         runInfo['MafDir'] = run['mafDir']
+        runInfo['ResultsDb'] = os.path.join(run['mafDir'], 'resultsDb_sqlite.db')
         runInfo['OpsimDate'] = run['opsimDate']
         runInfo['MafDate'] = run['mafDate']
         return runInfo

--- a/python/lsst/sims/maf/viz/templates/runselect.html
+++ b/python/lsst/sims/maf/viz/templates/runselect.html
@@ -40,9 +40,13 @@ List of all Opsim Runs
   <tr>
   {% for key in runInfo %}
     {% if loop.index == 1 %}
-       <td><a href="metricSelect?runId={{run['mafRunId']}}">{{ runInfo[key]|escape }} </a> </td>
+       <td><a href="metricSelect?runId={{run['mafRunId']}}">{{runInfo[key]|escape }} </a> </td>
+    {% elif key == 'SQLite File' %}
+       <td><a href="{{runInfo[key][0]}}" download>{{runInfo[key][1]|escape}}</a> </td>
+    {% elif key == 'ResultsDb' %}
+       <td><a href="{{runInfo[key]}}" download>ResultsDb</a> </td>
     {% else %}
-      <td>{{ runInfo[key]|escape }}   </td>
+      <td>{{ runInfo[key]|escape }} </td>
     {% endif %}
   {% endfor %}
   </tr>

--- a/tests/testTrackingDb.py
+++ b/tests/testTrackingDb.py
@@ -15,6 +15,7 @@ class TestTrackingDb(unittest.TestCase):
         self.trackingDb = 'trackingDb_sqlite.db'
         self.mafDate = '1/1/11'
         self.opsimDate = '1/1/11'
+        self.dbFile = None
 
     def tearDown(self):
         if os.path.isfile(self.trackingDb):
@@ -29,22 +30,25 @@ class TestTrackingDb(unittest.TestCase):
     def testAddRun(self):
         """Test adding a run to the tracking database."""
         trackingdb = db.TrackingDb(database=self.trackingDb)
-        trackId = trackingdb.addRun(opsimRun = self.opsimRun, opsimComment = self.opsimComment,
-                                    mafComment = self.mafComment, mafDir = self.mafDir,
-                                    mafDate = self.mafDate, opsimDate = self.opsimDate)
+        trackId = trackingdb.addRun(opsimRun=self.opsimRun, opsimComment=self.opsimComment,
+                                    mafComment=self.mafComment, mafDir=self.mafDir,
+                                    mafDate=self.mafDate, opsimDate=self.opsimDate,
+                                    dbFile=self.dbFile)
         tdb = db.Database(database=self.trackingDb,
-                            dbTables={'runs':['runs', 'mafRunId']})
+                            dbTables={'runs': ['runs', 'mafRunId']})
         res = tdb.queryDatabase('runs', 'select * from runs')
         self.assertEqual(res['mafRunId'][0], trackId)
         # Try adding this run again. Should just return previous trackId without adding.
-        trackId2 = trackingdb.addRun(opsimRun = self.opsimRun, opsimComment = self.opsimComment,
-                                     mafComment = self.mafComment, mafDir = self.mafDir,
-                                     mafDate = self.mafDate, opsimDate = self.opsimDate)
+        trackId2 = trackingdb.addRun(opsimRun=self.opsimRun, opsimComment=self.opsimComment,
+                                     mafComment=self.mafComment, mafDir=self.mafDir,
+                                     mafDate=self.mafDate, opsimDate=self.opsimDate,
+                                     dbFile=self.dbFile)
         self.assertEqual(trackId, trackId2)
         # Test will add run, if we use 'override=True'. Also works to use None's.
-        trackId3 = trackingdb.addRun(opsimRun = None, opsimComment=None, mafComment=None,
-                                     mafDir = self.mafDir, override=True,
-                                     mafDate = self.mafDate, opsimDate = self.opsimDate)
+        trackId3 = trackingdb.addRun(opsimRun=None, opsimComment=None, mafComment=None,
+                                     mafDir=self.mafDir, override=True,
+                                     mafDate=self.mafDate, opsimDate=self.opsimDate,
+                                     dbFile=self.dbFile)
         self.assertNotEqual(trackId, trackId3)
         trackingdb.close()
 
@@ -54,9 +58,10 @@ class TestTrackingDb(unittest.TestCase):
         tdb = db.Database(database=self.trackingDb,
                           dbTables={'runs':['runs', 'mafRunId']})
         # Add a run.
-        trackId = trackingdb.addRun(opsimRun = self.opsimRun, opsimComment = self.opsimComment,
-                                    mafComment = self.mafComment, mafDir = self.mafDir,
-                                    mafDate = self.mafDate, opsimDate = self.opsimDate)
+        trackId = trackingdb.addRun(opsimRun=self.opsimRun, opsimComment=self.opsimComment,
+                                    mafComment=self.mafComment, mafDir=self.mafDir,
+                                    mafDate=self.mafDate, opsimDate=self.opsimDate,
+                                    dbFile=self.dbFile)
         res = tdb.queryDatabase('runs', 'select * from runs')
         self.assertEqual(res['mafRunId'][0], trackId)
         # Test removal works.


### PR DESCRIPTION
…base file.

This lets the showMaf pages add a link for downloading the sqlite db file.
At the same time, I added a link to download the 'resultsDB' directly from the runlist page.