### PR TITLE
ParallaxHADegenMetric: uses Pearson instead of Spearman correlation 

### DIFF
--- a/python/lsst/sims/maf/metrics/calibrationMetrics.py
+++ b/python/lsst/sims/maf/metrics/calibrationMetrics.py
@@ -295,7 +295,7 @@ class ParallaxHADegenMetric(BaseMetric):
         seeingCol = column name for seeing (assumed FWHM)
         rmag = mag of fiducial star in r filter.  Other filters are scaled using sedTemplate keyword
         sedTemplate = template to use (can be 'flat' or 'O','B','A','F','G','K','M')
-        useSpearmanR = use spearman-r coefficient for correlation? (Default False
+        useSpearmanR = use spearman-r coefficient for correlation? (Default False)
         """
 
         cols = ['ra_pi_amp', 'dec_pi_amp']


### PR DESCRIPTION
Following feedback on the Observing Whitepaper Chapter 4 discussion of Astrometry metrics.

Change made: here the parallax hour angle degeneracy metric uses **scipy.stats.pearsonr** to compute the correlation coefficient by default (instead of **scipy.stats.spearmanr**). Set argument **useSpearmanR=True** to revert to previous behavior.

@dgmonet @yoachim @rhiannonlynne 

