### PR TITLE
Bugfix/sim 2024 user points slicer

### DIFF
--- a/doc/source/modules.rst
+++ b/doc/source/modules.rst
@@ -1,7 +1,7 @@
-Python API documentation
-========================
+python
+======
 
 .. toctree::
    :maxdepth: 4
 
-   lsst.sims.maf
+   lsst

--- a/python/lsst/sims/maf/slicers/baseSlicer.py
+++ b/python/lsst/sims/maf/slicers/baseSlicer.py
@@ -41,27 +41,30 @@ class SlicerRegistry(type):
 class BaseSlicer(object):
     """
     Base class for all slicers: sets required methods and implements common functionality.
+
+    After first construction, the slicer should be ready for setupSlicer to define slicePoints, which will
+    let the slicer 'slice' data and generate plots.
+    After init after a restore: everything necessary for using slicer for plotting or
+    saving/restoring metric data should be present (although slicer does not need to be able to
+    slice data again and generally will not be able to).
+
+    The sliceMetric has a 'memo-ize' functionality that can save previous indexes & return
+    metric data value calculated for same set of previous indexes, if desired.
+    CacheSize = 0 effectively turns this off, otherwise cacheSize should be set by the slicer.
+    (Most useful for healpix slicer, where many healpixels may have same set of LSST visits).
+
+    Parameters
+    ----------
+    verbose: boolean, optional
+        True/False flag to send extra output to screen.
+        Default True.
+    badval: int or float, optional
+        The value the Slicer uses to fill masked metric data values
+        Default -666.
     """
     __metaclass__ = SlicerRegistry
 
     def __init__(self, verbose=True, badval=-666):
-        """Instantiate the base slicer object.
-
-        After first init with a 'blank' slicer: slicer should be ready for setupSlicer to
-        define slicePoints.
-        After init after a restore: everything necessary for using slicer for plotting or
-        saving/restoring metric data should be present (although slicer does not need to be able to
-        slice data again and generally will not be able to).
-
-        The sliceMetric has a 'memo-ize' functionality that can save previous indexes & return
-        metric data value calculated for same set of previous indexes, if desired.
-        CacheSize = 0 effectively turns this off, otherwise cacheSize should be set by the slicer.
-        (Most useful for healpix slicer, where many healpixels may have same set of LSST visits).
-
-        Minimum set of __init__ kwargs:
-        verbose: True/False flag to send extra output to screen
-        badval: the value the Slicer uses to fill masked metric data values
-        """
         self.verbose = verbose
         self.badval = badval
         # Set cacheSize : each slicer will be able to override if appropriate.
@@ -86,7 +89,6 @@ class BaseSlicer(object):
         # Set the y-axis range be on the two-d plot
         if self.nslice is not None:
             self.spatialExtent = [0,self.nslice-1]
-
 
     def _runMaps(self, maps):
         """Add map metadata to slicePoints.

--- a/python/lsst/sims/maf/slicers/baseSlicer.py
+++ b/python/lsst/sims/maf/slicers/baseSlicer.py
@@ -48,11 +48,6 @@ class BaseSlicer(object):
     saving/restoring metric data should be present (although slicer does not need to be able to
     slice data again and generally will not be able to).
 
-    The sliceMetric has a 'memo-ize' functionality that can save previous indexes & return
-    metric data value calculated for same set of previous indexes, if desired.
-    CacheSize = 0 effectively turns this off, otherwise cacheSize should be set by the slicer.
-    (Most useful for healpix slicer, where many healpixels may have same set of LSST visits).
-
     Parameters
     ----------
     verbose: boolean, optional
@@ -102,6 +97,13 @@ class BaseSlicer(object):
 
         Set up internal parameters necessary for slicer to slice data and generates indexes on simData.
         Also sets _sliceSimData for a particular slicer.
+
+        Parameters
+        -----------
+        simData : np.recarray
+            The simulated data to be sliced.
+        maps : list of lsst.sims.maf.maps objects, optional.
+            Maps to apply at each slicePoint, to add to the slicePoint metadata. Default None.
         """
         # Typically args will be simData, but opsimFieldSlicer also uses fieldData.
         raise NotImplementedError()
@@ -169,8 +171,12 @@ class BaseSlicer(object):
         """
         Save metric values along with the information required to re-build the slicer.
 
-        outfilename: the output file
-        metricValues: the metric values to save to disk
+        Parameters
+        -----------
+        outfilename : str
+            The output file name.
+        metricValues : np.ma.MaskedArray or np.ndarray
+            The metric values to save to disk.
         """
         header = {}
         header['metricName']=metricName
@@ -210,14 +216,29 @@ class BaseSlicer(object):
         """
         Send metric data to JSON streaming API, along with a little bit of metadata.
 
-        Output is
-        header dictionary with 'metricName/metadata/simDataName/slicerName' and plot labels from plotDict (if provided).
-        then data for plot:
-        if oneDSlicer, it's [ [bin_left_edge, value], [bin_left_edge, value]..].
-        if a spatial slicer, it's [ [lon, lat, value], [lon, lat, value] ..].
-
-        This method will only work for non-complex metrics (i.e. metrics where the metric value is a float or int),
+        This method will only work for metrics where the metricDtype is float or int,
         as JSON will not interpret more complex data properly. These values can't be plotted anyway though.
+
+        Parameters
+        -----------
+        metricValues : np.ma.MaskedArray or np.ndarray
+            The metric values.
+        metricName : str, optional
+            The name of the metric. Default ''.
+        simDataName : str, optional
+            The name of the simulated data source. Default ''.
+        metadata : str, optional
+            The metadata about this metric. Default ''.
+        plotDict : dict, optional.
+            The plotDict for this metric bundle. Default None.
+
+        Returns
+        --------
+        StringIO
+            StringIO object containing a header dictionary with metricName/metadata/simDataName/slicerName,
+            and plot labels from plotDict, and metric values/data for plot.
+            if oneDSlicer, the data is [ [bin_left_edge, value], [bin_left_edge, value]..].
+            if a spatial slicer, the data is [ [lon, lat, value], [lon, lat, value] ..].
         """
         # Bail if this is not a good data type for JSON.
         if not (metricValues.dtype == 'float') or (metricValues.dtype == 'int'):
@@ -309,7 +330,16 @@ class BaseSlicer(object):
         """
         Read metric data from disk, along with the info to rebuild the slicer (minus new slicing capability).
 
-        infilename: the filename containing the metric data.
+        Parameters
+        -----------
+        infilename: str
+            The filename containing the metric data.
+
+        Returns
+        -------
+        np.ma.MaskedArray, lsst.sims.maf.slicer, dict
+            MetricValues stored in data file, the slicer basis for those metric values, and a dictionary
+            containing header information (runName, metadata, etc.).
         """
         import lsst.sims.maf.slicers as slicers
         restored = np.load(infilename)

--- a/python/lsst/sims/maf/slicers/opsimFieldSlicer.py
+++ b/python/lsst/sims/maf/slicers/opsimFieldSlicer.py
@@ -9,29 +9,49 @@ from .baseSpatialSlicer import BaseSpatialSlicer
 
 __all__ = ['OpsimFieldSlicer']
 
+
 class OpsimFieldSlicer(BaseSpatialSlicer):
-    """Index-based slicer, matched ID's between simData and fieldData.
+    """A spatial slicer that evaluates pointings based on matched IDs between the simData and fieldData.
 
-    Slicer uses fieldData RA and Dec values to do sky map plotting, but could be used more
-    generally for any kind of data slicing where the match is based on a simple ID value.
+    Note that this slicer uses the fieldID of the simulated data fields to generate the spatial matches.
+    Thus, it is not suitable for use in evaluating dithering or high resolution metrics
+    (use the HealpixSlicer instead for those use-cases).
 
-    Note that this slicer uses the fieldID of the opsim fields to generate spatial matches,
-    thus this slicer is not suitable for use in evaluating dithering or high resolution metrics
-    (use the healpix slicer instead for those use-cases). """
+    When the slicer is set up, it takes two arrays: fieldData and simData. FieldData is a numpy.recarray
+    containing the information about the fields - this is the basis for slicing.
+    The simData is a numpy.recarray that holds the information about the pointings - this is the data that
+    is matched against the fieldData.
 
-    def __init__(self, verbose=True, simDataFieldIDColName='fieldID',
+    Parameters
+    ----------
+    simDataFieldIDColName : str, optional
+        Name of the column in simData for the fieldID
+        Default fieldID.
+    simDataFieldRaColName : str, optional
+        Name of the column in simData for the fieldRA.
+        Default fieldRA.
+    simDataFieldDecColName : str, optional
+        Name of the column in simData for the fieldDec.
+        Default fieldDec.
+    fieldIDColName : str, optional
+        Name of the column in the fieldData for the fieldID (to match with simData).
+        Default fieldID.
+    fieldRAColName : str, optional
+        Name of the column in the fieldData for the fieldRA (used for plotting).
+        Default fieldDec.
+    fieldDecColName : str, optional
+        Name of the column in the fieldData for the fieldDec (used for plotting).
+        Default fieldRA.
+    verbose : boolean, optional
+        Flag to indicate whether or not to write additional information to stdout during runtime.
+        Default True.
+    badval : float, optional
+        Bad value flag, relevant for plotting. Default -666.
+    """
+    def __init__(self, simDataFieldIDColName='fieldID',
                  simDataFieldRaColName='fieldRA', simDataFieldDecColName='fieldDec',
                  fieldIDColName='fieldID', fieldRaColName='fieldRA', fieldDecColName='fieldDec',
-                 badval=-666):
-        """Instantiate opsim field slicer (an index-based slicer that can do spatial plots).
-
-        simDataFieldIDColName = the column name in simData for the field ID
-        simDataFieldRaColName = the column name in simData for the field RA
-        simDataFieldDecColName = the column name in simData for the field Dec
-        fieldIDcolName = the column name in the fieldData for the field ID (to match with simData)
-        fieldRaColName = the column name in the fieldData for the field RA (for plotting only)
-        fieldDecColName = the column name in the fieldData for the field Dec (for plotting only).
-        """
+                 verbose=True, badval=-666):
         super(OpsimFieldSlicer, self).__init__(verbose=verbose, badval=badval)
         self.fieldID = None
         self.simDataFieldIDColName = simDataFieldIDColName
@@ -39,26 +59,32 @@ class OpsimFieldSlicer(BaseSpatialSlicer):
         self.fieldRaColName = fieldRaColName
         self.fieldDecColName = fieldDecColName
         self.columnsNeeded = [simDataFieldIDColName, simDataFieldRaColName, simDataFieldDecColName]
-        while '' in self.columnsNeeded: self.columnsNeeded.remove('')
+        while '' in self.columnsNeeded:
+            self.columnsNeeded.remove('')
         self.fieldColumnsNeeded = [fieldIDColName, fieldRaColName, fieldDecColName]
-        self.slicer_init={'simDataFieldIDColName':simDataFieldIDColName,
-                          'simDataFieldRaColName':simDataFieldRaColName,
-                          'simDataFieldDecColName':simDataFieldDecColName,
-                          'fieldIDColName':fieldIDColName,
-                          'fieldRaColName':fieldRaColName,
-                          'fieldDecColName':fieldDecColName, 'badval':badval}
+        self.slicer_init = {'simDataFieldIDColName': simDataFieldIDColName,
+                            'simDataFieldRaColName': simDataFieldRaColName,
+                            'simDataFieldDecColName': simDataFieldDecColName,
+                            'fieldIDColName': fieldIDColName,
+                            'fieldRaColName': fieldRaColName,
+                            'fieldDecColName': fieldDecColName, 'badval': badval}
         self.plotFuncs = [BaseSkyMap, OpsimHistogram]
         self.needsFields = True
-
 
     def setupSlicer(self, simData, fieldData, maps=None):
         """Set up opsim field slicer object.
 
-        simData = numpy rec array with simulation pointing history,
-        fieldData = numpy rec array with the field information (ID, RA, Dec),
-        Values for the column names are set during 'init'.
+        Parameters
+        -----------
+        simData : numpy.recarray
+            Contains the simulation pointing history.
+        fieldData : numpy.recarray
+            Contains the field information (ID, Ra, Dec) about how to slice the simData.
+            For example, only fields in the fieldData table will be matched against the simData.
+        maps : list of lsst.sims.maf.maps objects, optional
+            Maps to run and provide additional metadata at each slicePoint. Default None.
         """
-        if hasattr(self,'slicePoints'):
+        if hasattr(self, 'slicePoints'):
             warning_msg = 'Warning: this OpsimFieldSlicer was already set up once. '
             warning_msg += 'Re-setting up an OpsimFieldSlicer can change the field information. '
             warning_msg += 'Rerun metrics if this was intentional. '
@@ -78,34 +104,33 @@ class OpsimFieldSlicer(BaseSpatialSlicer):
         self.right = np.searchsorted(simFieldsSorted, self.slicePoints['sid'], 'right')
 
         self.spatialExtent = [simData[self.simDataFieldIDColName].min(),
-                                  simData[self.simDataFieldIDColName].max()]
+                              simData[self.simDataFieldIDColName].max()]
         self.shape = self.nslice
 
         @wraps(self._sliceSimData)
-
         def _sliceSimData(islice):
             idxs = self.simIdxs[self.left[islice]:self.right[islice]]
             # Build dict for slicePoint info
-            slicePoint={}
+            slicePoint = {}
             for key in self.slicePoints.keys():
-                if (np.shape(self.slicePoints[key])[0] == self.nslice) & (key is not 'bins') & (key is not 'binCol'):
+                if (np.shape(self.slicePoints[key])[0] == self.nslice) & \
+                        (key is not 'bins') & (key is not 'binCol'):
                     slicePoint[key] = self.slicePoints[key][islice]
                 else:
                     slicePoint[key] = self.slicePoints[key]
-            return {'idxs':idxs, 'slicePoint':slicePoint}
+            return {'idxs': idxs, 'slicePoint': slicePoint}
         setattr(self, '_sliceSimData', _sliceSimData)
 
     def __eq__(self, otherSlicer):
         """Evaluate if two grids are equivalent."""
-
         result = False
         if isinstance(otherSlicer, OpsimFieldSlicer):
             if np.all(otherSlicer.shape == self.shape):
                 # Check if one or both slicers have been setup
                 if (self.slicePoints['ra'] is not None) or (otherSlicer.slicePoints['ra'] is not None):
                     if (np.array_equal(self.slicePoints['ra'], otherSlicer.slicePoints['ra']) &
-                        np.array_equal(self.slicePoints['dec'], otherSlicer.slicePoints['dec']) &
-                        np.array_equal(self.slicePoints['sid'], otherSlicer.slicePoints['sid'])):
+                            np.array_equal(self.slicePoints['dec'], otherSlicer.slicePoints['dec']) &
+                            np.array_equal(self.slicePoints['sid'], otherSlicer.slicePoints['sid'])):
                         result = True
                 # If they have not been setup, check that they have same fields
                 elif ((otherSlicer.fieldIDColName == self.fieldIDColName) &

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -85,25 +85,25 @@ class TestSlicers(unittest.TestCase):
                 assert(getattr(slicer,att) == getattr(slicerBack,att))
 
     def test_opsimFieldSlicer(self):
-        slicer=slicers.OpsimFieldSlicer(np.arange(100))
-        names=['fieldRA','fieldDec','fieldID',]
-        dt = ['float','float','int']
+        slicer=slicers.OpsimFieldSlicer()
+        names = ['fieldRA','fieldDec','fieldID']
+        dt = ['float', 'float', 'int']
         metricValues = np.random.rand(100)
-        fieldData = np.zeros(100, dtype=zip(names,dt))
+        fieldData = np.zeros(100, dtype=zip(names, dt))
         fieldData['fieldRA'] = np.random.rand(100)
         fieldData['fieldDec'] = np.random.rand(100)
         fieldData['fieldID'] = np.arange(100)
-        names=['data1','data2','fieldID',]
-        simData = np.zeros(100, dtype=zip(names,dt))
+        names=['data1','data2','fieldID']
+        simData = np.zeros(100, dtype=zip(names, dt))
         simData['data1'] = np.random.rand(100)
         simData['fieldID'] = np.arange(100)
-        slicer.setupSlicer(simData,fieldData)
+        slicer.setupSlicer(simData, fieldData)
         filename = 'opsimslicer_test.npz'
         self.filenames.append(filename)
         slicer.writeData(filename, metricValues)
-        metricBack, slicerBack,header = self.baseslicer.readData(filename)
+        metricBack, slicerBack, header = self.baseslicer.readData(filename)
         assert(slicer == slicerBack)
-        np.testing.assert_almost_equal(metricBack,metricValues)
+        np.testing.assert_almost_equal(metricBack, metricValues)
         attr2check = ['nslice', 'columnsNeeded', 'lonCol', 'latCol','simDataFieldIDColName']
         for att in attr2check:
             if type(getattr(slicer,att)).__name__ == 'dict':


### PR DESCRIPTION
UserPointsSlicer had some problems. 

This PR fixes: 
- couldn't use more than one metric in a bundle group with a userPointsSlicer, as the _eq_ was broken.
- couldn't read back in data from disk, as the slicer_init parameter was missing.

Also updated API documentation for most of the spatial slicers.