### PR TITLE
Feature/sim 2112/write end2end scripts

### DIFF
--- a/tests/testDB.py
+++ b/tests/testDB.py
@@ -5,9 +5,14 @@ import unittest
 import numpy as np
 import lsst.sims.maf.db as db
 import lsst.utils.tests
+from lsst.sims.catalogs.db import _close_all_connections
 
 
 class TestDb(unittest.TestCase):
+
+    @classmethod
+    def tearDownClass(cls):
+        _close_all_connections()
 
     def setUp(self):
         self.database = os.path.join(os.getenv('SIMS_MAF_DIR'),

--- a/tests/testDB.py
+++ b/tests/testDB.py
@@ -5,14 +5,14 @@ import unittest
 import numpy as np
 import lsst.sims.maf.db as db
 import lsst.utils.tests
-from lsst.sims.catalogs.db import _close_all_connections
+from lsst.sims.utils.CodeUtilities import sims_clean_up
 
 
 class TestDb(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        _close_all_connections()
+        sims_clean_up()
 
     def setUp(self):
         self.database = os.path.join(os.getenv('SIMS_MAF_DIR'),

--- a/tests/testDustMap.py
+++ b/tests/testDustMap.py
@@ -2,9 +2,14 @@ import unittest
 import numpy as np
 from lsst.sims.photUtils import EBV
 import lsst.utils.tests
+from lsst.sims.utils.CodeUtilities import sims_clean_up
 
 
 class TestDustMap(unittest.TestCase):
+
+    @classmethod
+    def tearDownClass(cls):
+        sims_clean_up()
 
     def testCreate(self):
         """ Test that we can create the dustmap"""

--- a/tests/testMetricBundle.py
+++ b/tests/testMetricBundle.py
@@ -10,9 +10,14 @@ import glob
 import os
 import shutil
 import lsst.utils.tests
+from lsst.sims.catalogs.db import _close_all_connections
 
 
 class TestMetricBundle(unittest.TestCase):
+
+    @classmethod
+    def tearDownClass(cls):
+        _close_all_connections()
 
     def setUp(self):
         self.outDir = 'TMB'

--- a/tests/testMetricBundle.py
+++ b/tests/testMetricBundle.py
@@ -10,14 +10,14 @@ import glob
 import os
 import shutil
 import lsst.utils.tests
-from lsst.sims.catalogs.db import _close_all_connections
+from lsst.sims.utils.CodeUtilities import sims_clean_up
 
 
 class TestMetricBundle(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        _close_all_connections()
+        sims_clean_up()
 
     def setUp(self):
         self.outDir = 'TMB'

--- a/tests/testOpsimDb.py
+++ b/tests/testOpsimDb.py
@@ -6,7 +6,7 @@ import numpy as np
 import lsst.sims.maf.db as db
 import lsst.sims.maf.utils.outputUtils as out
 import lsst.utils.tests
-from lsst.sims.catalogs.db import _close_all_connections
+from lsst.sims.utils.CodeUtilities import sims_clean_up
 
 
 class TestOpsimDb(unittest.TestCase):
@@ -14,7 +14,7 @@ class TestOpsimDb(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        _close_all_connections()
+        sims_clean_up()
 
     def setUp(self):
         self.database = os.path.join(os.getenv('SIMS_MAF_DIR'), 'tests',

--- a/tests/testOpsimDb.py
+++ b/tests/testOpsimDb.py
@@ -6,10 +6,15 @@ import numpy as np
 import lsst.sims.maf.db as db
 import lsst.sims.maf.utils.outputUtils as out
 import lsst.utils.tests
+from lsst.sims.catalogs.db import _close_all_connections
 
 
 class TestOpsimDb(unittest.TestCase):
     """Test opsim specific database class."""
+
+    @classmethod
+    def tearDownClass(cls):
+        _close_all_connections()
 
     def setUp(self):
         self.database = os.path.join(os.getenv('SIMS_MAF_DIR'), 'tests',


### PR DESCRIPTION
This is one of many (one for each sims_* repo...) PRs related to my effort to create a seamless integration between OpSim, CatSim, and PhoSim for generating full-focal plane image simulations.

This pull request updates unit tests to use `sims_clean_up()`.