### PR TITLE
Bugfix/neodist stacker

### DIFF
--- a/python/lsst/sims/maf/maps/dustMap.py
+++ b/python/lsst/sims/maf/maps/dustMap.py
@@ -21,12 +21,13 @@ class DustMap(BaseMap):
         # If the slicer has nside, it's a healpix slicer so we can read the map directly
         if 'nside' in slicePoints:
             if slicePoints['nside'] != self.nside:
-                warnings.warn('Slicer value of nside (%i) different from map value (%i), using slicer value'%(slicePoints['nside'],self.nside ))
+                warnings.warn('Slicer value of nside (%i) different from map value (%i), using slicer value'
+                              % (slicePoints['nside'],self.nside ))
             slicePoints['ebv'] = EBVhp(slicePoints['nside'], pixels=slicePoints['sid'])
         # Not a healpix slicer, look up values based on RA,dec with possible interpolation
         else:
             slicePoints['ebv'] = EBVhp(self.nside, ra=slicePoints['ra'],
-                                            dec=slicePoints['dec'], interp=self.interp)
+                                       dec=slicePoints['dec'], interp=self.interp)
 
         return slicePoints
 

--- a/python/lsst/sims/maf/maps/galCoordsMap.py
+++ b/python/lsst/sims/maf/maps/galCoordsMap.py
@@ -1,9 +1,9 @@
 from lsst.sims.utils import _galacticFromEquatorial
 from lsst.sims.maf.maps import BaseMap
 
-__all__ = ['galCoordsMap']
+__all__ = ['GalCoordsMap']
 
-class galCoordsMap(BaseMap):
+class GalCoordsMap(BaseMap):
     def __init__(self):
         self.keynames = ['gall', 'galb']
 

--- a/python/lsst/sims/maf/stackers/NEODistStacker.py
+++ b/python/lsst/sims/maf/stackers/NEODistStacker.py
@@ -12,7 +12,7 @@ class NEODistStacker(BaseStacker):
 
     def __init__(self, m5Col='fiveSigmaDepth',
                  stepsize=.001, maxDist=3.,minDist=.3, H=22, elongCol='solarElong',
-                 filterCol='filter',sunAzCol='sunAz', azCol='azimuth', **kwargs):
+                 filterCol='filter',sunAzCol='sunAz', azCol='azimuth'):
 
         """
         stepsize:  The stepsize to use when solving (in AU)

--- a/python/lsst/sims/maf/stackers/baseStacker.py
+++ b/python/lsst/sims/maf/stackers/baseStacker.py
@@ -64,24 +64,18 @@ class BaseStacker(with_metaclass(StackerRegistry, object)):
         # Optional: provide a list of units for the columns defined in colsAdded.
         self.units = [None]
 
+    def __hash__(self):
+        return None
+
     def __eq__(self, otherStacker):
         """
         Evaluate if two stackers are equivalent.
         """
-        # Are we comparing two classes before instantiation?
-        if (self.__class__.__name__ == 'StackerRegistry' and
-            otherStacker.__class__.__name__ == 'StackerRegistry'):
-            if self.__name__ == otherStacker.__name__:
-                return True
-            else:
-                return False
-        # otherwise, we are not and these are instantiated stacker objects.
         # If the class names are different, they are not 'the same'.
         if self.__class__.__name__ != otherStacker.__class__.__name__:
             return False
         # Otherwise, this is the same stacker class, but may be instantiated differently.
-        #  We have to delve a little further, and look at the kwargs for each stacker.
-        # We assume that they are equal, unless they have specific attributes which are different.
+        # We have to delve a little further, and compare the kwargs & attributes for each stacker.
         stateNow = dir(self)
         for key in stateNow:
             if not key.startswith('_') and key != 'registry' and key != 'run' and key != 'next':

--- a/python/lsst/sims/maf/stackers/coordStackers.py
+++ b/python/lsst/sims/maf/stackers/coordStackers.py
@@ -9,8 +9,16 @@ __all__ = ['GalacticStacker',
            'EclipticStacker', 'mjd2djd']
 
 def mjd2djd(mjd):
-    """
-    Convert MJD to Dublin Julian Date used by ephem
+    """Convert MJD to the Dublin Julian date used by ephem.
+    
+    Parameters
+    ----------
+    mjd : float or numpy.ndarray
+        The modified julian date.
+    Returns
+    -------
+    float or numpy.ndarray
+        The dublin julian date.
     """
     doff = ephem.Date(0)-ephem.Date('1858/11/17')
     djd = mjd-doff
@@ -18,11 +26,17 @@ def mjd2djd(mjd):
 
 
 class GalacticStacker(BaseStacker):
-    """
-    Stack on the galactic coordinates of each pointing.
+    """Add the galactic coordinates of each RA/Dec pointing.
+
+    Parameters
+    ----------
+    raCol : str, opt
+        Name of the RA column. Default fieldRA.
+    decCol : str, opt
+        Name of the Dec column. Default fieldDec.
     """
     def __init__(self, raCol='fieldRA', decCol='fieldDec'):
-        self.colsReq = [raCol,decCol]
+        self.colsReq = [raCol, decCol]
         self.colsAdded = ['gall','galb']
         self.units = ['radians', 'radians']
         self.raCol = raCol
@@ -34,16 +48,26 @@ class GalacticStacker(BaseStacker):
         return simData
 
 class EclipticStacker(BaseStacker):
-    """
-    Stack on the ecliptic coordinates of each pointing.  Optionally
-    subtract off the sun's ecliptic longitude and wrap.
+    """Add the ecliptic coordinates of each RA/Dec pointing.
+    Optionally subtract off the sun's ecliptic longitude and wrap.
+    
+    Parameters
+    ----------
+    mjdCol : str, opt
+        Name of the MJD column. Default expMJD.
+    raCol : str, opt
+        Name of the RA column. Default fieldRA.
+    decCol : str, opt
+        Name of the Dec column. Default fieldDec.
+    subtractSunLon : bool, opt
+        Flag to subtract the sun's ecliptic longitude. Default False.
     """
     def __init__(self, mjdCol='expMJD', raCol='fieldRA',decCol='fieldDec',
                  subtractSunLon=False):
 
-        self.colsReq = [mjdCol,raCol,decCol]
+        self.colsReq = [mjdCol, raCol, decCol]
         self.subtractSunLon = subtractSunLon
-        self.colsAdded = ['eclipLat','eclipLon']
+        self.colsAdded = ['eclipLat', 'eclipLon']
         self.units = ['radians', 'radians']
         self.mjdCol = mjdCol
         self.raCol = raCol

--- a/tests/testMetricBundle.py
+++ b/tests/testMetricBundle.py
@@ -4,6 +4,8 @@ matplotlib.use("Agg")
 
 import lsst.sims.maf.metrics as metrics
 import lsst.sims.maf.slicers as slicers
+import lsst.sims.maf.stackers as stackers
+import lsst.sims.maf.maps as maps
 import lsst.sims.maf.metricBundles as metricBundles
 import lsst.sims.maf.db as db
 import glob
@@ -26,11 +28,16 @@ class TestMetricBundle(unittest.TestCase):
         """
         Check that the metric bundle can generate the expected output
         """
-        slicer = slicers.HealpixSlicer(nside=8)
+        nside = 8
+        slicer = slicers.HealpixSlicer(nside=nside)
         metric = metrics.MeanMetric(col='airmass')
         sql = 'filter="r"'
+        stacker1 = stackers.RandomDitherFieldPerVisitStacker()
+        stacker2 = stackers.GalacticStacker()
+        map1 = maps.GalCoordsMap()
+        map2 = maps.StellarDensityMap()
 
-        metricB = metricBundles.MetricBundle(metric, slicer, sql)
+        metricB = metricBundles.MetricBundle(metric, slicer, sql, stackerList=[stacker1, stacker2])
         filepath = os.path.join(os.getenv('SIMS_MAF_DIR'), 'tests/')
 
         database = os.path.join(filepath, 'opsimblitz1_1133_sqlite.db')


### PR DESCRIPTION
Some whitespace changes and documentation updates.
But majority of change is in swapping out list(set(STACKERLIST)) because python3 changes how hashes are handled for classes where you've defined '__eq__'. 
In this case, I chose not to define '__hash__' for the stackers because 
(A) the stackers are not immutable after instantiation (although in practice, it would be very odd for someone to change any of the internal parameters)
(B) I can't think of use cases for the hash other than where we were using it -- to winnow down a group of stackers to only non-duplicate items. This group is typically short, so comparison on whether the stacker is already present in a list of non-duplicates vs using the hash to remove duplicates (via list(set(stackerlist))) shouldn't be too time consuming (I don't think the O(N) rather than O(1) trade will be too costly). 
(C) computing the hash in a way equivalent to how we were computing the equals (the best option) is expensive and can be impossible. The default way of computing a hash would be to take all of the components considered in "equals", combine them into a tuple, and hash the tuple. But because we were using all member variables of the class to compute "equals", this often includes numpy arrays .. which are also not hashable. If it were possible to only use the arguments to init instead of all member variables, this might be easier (although would impose the constraint of not using numpy arrays as arguments), but this is also not possible for all arbitrary child stackers.

So as a result, I did not define the hash of the class, but instead changed the list(set(stackerlist)) usage.