### PR TITLE
SIM-2424: Use getTempFilePath to create temp file names

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+
+def pytest_configure(config):
+    sys._is_in_pytest = True

--- a/tests/testDB.py
+++ b/tests/testDB.py
@@ -5,6 +5,7 @@ import unittest
 import numpy as np
 import lsst.sims.maf.db as db
 import lsst.utils.tests
+from lsst.utils import getPackageDir
 from lsst.sims.utils.CodeUtilities import sims_clean_up
 
 
@@ -15,8 +16,8 @@ class TestDb(unittest.TestCase):
         sims_clean_up()
 
     def setUp(self):
-        self.database = os.path.join(os.getenv('SIMS_MAF_DIR'),
-                                     'tests', 'opsimblitz1_1133_sqlite.db')
+        self.database = os.path.join(getPackageDir('sims_data'),
+                                     'OpSimData', 'opsimblitz1_1133_sqlite.db')
         self.driver = 'sqlite'
 
     def tearDown(self):

--- a/tests/testMetricBundle.py
+++ b/tests/testMetricBundle.py
@@ -12,6 +12,7 @@ import glob
 import os
 import shutil
 import lsst.utils.tests
+from lsst.utils import getPackageDir
 from lsst.sims.utils.CodeUtilities import sims_clean_up
 
 
@@ -38,9 +39,8 @@ class TestMetricBundle(unittest.TestCase):
         map2 = maps.StellarDensityMap()
 
         metricB = metricBundles.MetricBundle(metric, slicer, sql, stackerList=[stacker1, stacker2])
-        filepath = os.path.join(os.getenv('SIMS_MAF_DIR'), 'tests/')
 
-        database = os.path.join(filepath, 'opsimblitz1_1133_sqlite.db')
+        database = os.path.join(getPackageDir('sims_data'), 'OpSimData', 'opsimblitz1_1133_sqlite.db')
         opsdb = db.OpsimDatabase(database=database)
         resultsDb = db.ResultsDb(outDir=self.outDir)
 

--- a/tests/testOpsimDb.py
+++ b/tests/testOpsimDb.py
@@ -6,6 +6,7 @@ import numpy as np
 import lsst.sims.maf.db as db
 import lsst.sims.maf.utils.outputUtils as out
 import lsst.utils.tests
+from lsst.utils import getPackageDir
 from lsst.sims.utils.CodeUtilities import sims_clean_up
 from builtins import str
 
@@ -18,7 +19,7 @@ class TestOpsimDb(unittest.TestCase):
         sims_clean_up()
 
     def setUp(self):
-        self.database = os.path.join(os.getenv('SIMS_MAF_DIR'), 'tests',
+        self.database = os.path.join(getPackageDir('sims_data'), 'OpSimData',
                                      'opsimblitz1_1133_sqlite.db')
         self.oo = db.OpsimDatabase(database=self.database)
 

--- a/tests/testOpsimFieldSlicer.py
+++ b/tests/testOpsimFieldSlicer.py
@@ -168,7 +168,6 @@ class TestOpsimFieldSlicerEqual(unittest.TestCase):
 class TestOpsimFieldSlicerWarning(unittest.TestCase):
 
     def setUp(self):
-        warnings.simplefilter('always')
         self.testslicer = OpsimFieldSlicer()
         self.fieldData = makeFieldData()
         self.simData = makeDataValues(self.fieldData)
@@ -178,6 +177,7 @@ class TestOpsimFieldSlicerWarning(unittest.TestCase):
         self.testslicer = None
 
     def testWarning(self):
+        warnings.simplefilter('always')
         self.testslicer.setupSlicer(self.simData, self.fieldData)
         with warnings.catch_warnings(record=True) as w:
             self.testslicer.setupSlicer(self.simData, self.fieldData)

--- a/tests/testOpsimFieldSlicer.py
+++ b/tests/testOpsimFieldSlicer.py
@@ -11,6 +11,7 @@ from lsst.sims.maf.slicers.opsimFieldSlicer import OpsimFieldSlicer
 from lsst.sims.maf.slicers.uniSlicer import UniSlicer
 import warnings
 import lsst.utils.tests
+import sys
 
 warnings.simplefilter('always')
 
@@ -176,8 +177,11 @@ class TestOpsimFieldSlicerWarning(unittest.TestCase):
         del self.testslicer
         self.testslicer = None
 
+    @unittest.skipIf(hasattr(sys, '_is_in_pytest') and
+                     sys.version_info.major==2,
+                     "This test fails in pytest with python 2, but only "
+                     "on Jenkins, for some reason")
     def testWarning(self):
-        warnings.simplefilter('always')
         self.testslicer.setupSlicer(self.simData, self.fieldData)
         with warnings.catch_warnings(record=True) as w:
             self.testslicer.setupSlicer(self.simData, self.fieldData)

--- a/tests/testOpsimFieldSlicer.py
+++ b/tests/testOpsimFieldSlicer.py
@@ -168,6 +168,7 @@ class TestOpsimFieldSlicerEqual(unittest.TestCase):
 class TestOpsimFieldSlicerWarning(unittest.TestCase):
 
     def setUp(self):
+        warnings.simplefilter('always')
         self.testslicer = OpsimFieldSlicer()
         self.fieldData = makeFieldData()
         self.simData = makeDataValues(self.fieldData)

--- a/tests/testResultsDb.py
+++ b/tests/testResultsDb.py
@@ -7,14 +7,18 @@ import warnings
 import unittest
 import numpy as np
 import lsst.sims.maf.db as db
+import tempfile
 import shutil
 import lsst.utils.tests
+
+
+ROOT = os.path.abspath(os.path.dirname(__file__))
 
 
 class TestResultsDb(unittest.TestCase):
 
     def setUp(self):
-        self.outDir = 'Out'
+        self.outDir = tempfile.mkdtemp(dir=ROOT, prefix='TestResultsDb')
         self.metricName = 'Count ExpMJD'
         self.slicerName = 'OneDSlicer'
         self.runName = 'fakeopsim'
@@ -89,7 +93,7 @@ class TestResultsDb(unittest.TestCase):
 class TestUseResultsDb(unittest.TestCase):
 
     def setUp(self):
-        self.outDir = 'Out'
+        self.outDir = tempfile.mkdtemp(dir=ROOT, prefix='TestUseResultsDb')
         self.metricName = 'Count ExpMJD'
         self.slicerName = 'OneDSlicer'
         self.runName = 'fakeopsim'

--- a/tests/testTrackingDb.py
+++ b/tests/testTrackingDb.py
@@ -1,7 +1,12 @@
 import os
 import unittest
+import tempfile
+import shutil
 import lsst.sims.maf.db as db
 import lsst.utils.tests
+
+
+ROOT = os.path.abspath(os.path.dirname(__file__))
 
 
 class TestTrackingDb(unittest.TestCase):
@@ -12,7 +17,9 @@ class TestTrackingDb(unittest.TestCase):
         self.opsimComment = 'opsimcomment'
         self.mafComment = 'mafcomment'
         self.mafDir = 'mafdir'
-        self.trackingDb = 'trackingDb_sqlite.db'
+        self.trackingDb = tempfile.mktemp(dir=ROOT,
+                                          prefix='trackingDb_sqlite',
+                                          suffix='.db')
         self.mafVersion = '1.0'
         self.mafDate = '2017-01-01'
         self.opsimVersion = '4.0'

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -13,7 +13,6 @@ import lsst.utils.tests
 class TestSlicers(unittest.TestCase):
 
     def setUp(self):
-        self.filenames = []
         self.baseslicer = slicers.BaseSlicer()
 
     def test_healpixSlicer_obj(self):
@@ -24,11 +23,10 @@ class TestSlicers(unittest.TestCase):
                                       mask=np.where(metricValues < .1, True, False),
                                       fill_value=slicer.badval)
         metricName = 'Noise'
-        filename = 'healpix_test.npz'
-        self.filenames.append(filename)
-        metadata = 'testdata'
-        slicer.writeData(filename, metricValues, metadata=metadata)
-        metricValuesBack, slicerBack, header = self.baseslicer.readData(filename)
+        with lsst.utils.tests.getTempFilePath(".npz") as filename:
+            metadata = 'testdata'
+            slicer.writeData(filename, metricValues, metadata=metadata)
+            metricValuesBack, slicerBack, header = self.baseslicer.readData(filename)
         np.testing.assert_almost_equal(metricValuesBack, metricValues)
         assert(slicer == slicerBack)
         assert(metadata == header['metadata'])
@@ -41,10 +39,9 @@ class TestSlicers(unittest.TestCase):
         slicer = slicers.HealpixSlicer(nside=nside)
         metricValues = np.random.rand(hp.nside2npix(nside))
         metricName = 'Noise'
-        filename = 'healpix_test.npz'
-        self.filenames.append(filename)
-        slicer.writeData(filename, metricValues, metadata='testdata')
-        metricValuesBack, slicerBack, header = self.baseslicer.readData(filename)
+        with lsst.utils.tests.getTempFilePath(".npz") as filename:
+            slicer.writeData(filename, metricValues, metadata='testdata')
+            metricValuesBack, slicerBack, header = self.baseslicer.readData(filename)
         np.testing.assert_almost_equal(metricValuesBack, metricValues)
         assert(slicer == slicerBack)
         attr2check = ['nside', 'nslice', 'columnsNeeded', 'lonCol', 'latCol']
@@ -59,10 +56,9 @@ class TestSlicers(unittest.TestCase):
                                       mask=np.where(metricValues < .1, True, False),
                                       fill_value=slicer.badval)
         metricName = 'Noise'
-        filename = 'healpix_test.npz'
-        self.filenames.append(filename)
-        slicer.writeData(filename, metricValues, metadata='testdata')
-        metricValuesBack, slicerBack, header = self.baseslicer.readData(filename)
+        with lsst.utils.tests.getTempFilePath(".npz") as filename:
+            slicer.writeData(filename, metricValues, metadata='testdata')
+            metricValuesBack, slicerBack, header = self.baseslicer.readData(filename)
         np.testing.assert_almost_equal(metricValuesBack, metricValues)
         assert(slicer == slicerBack)
         attr2check = ['nside', 'nslice', 'columnsNeeded', 'lonCol', 'latCol']
@@ -74,10 +70,9 @@ class TestSlicers(unittest.TestCase):
         dataValues = np.zeros(10000, dtype=[('testdata', 'float')])
         dataValues['testdata'] = np.random.rand(10000)
         slicer.setupSlicer(dataValues)
-        filename = 'oned_test.npz'
-        self.filenames.append(filename)
-        slicer.writeData(filename, dataValues[:100])
-        dataBack, slicerBack, header = self.baseslicer.readData(filename)
+        with lsst.utils.tests.getTempFilePath(".npz") as filename:
+            slicer.writeData(filename, dataValues[:100])
+            dataBack, slicerBack, header = self.baseslicer.readData(filename)
         assert(slicer == slicerBack)
         # np.testing.assert_almost_equal(dataBack,dataValues[:100])
         attr2check = ['nslice', 'columnsNeeded']
@@ -101,10 +96,9 @@ class TestSlicers(unittest.TestCase):
         simData['data1'] = np.random.rand(100)
         simData['fieldID'] = np.arange(100)
         slicer.setupSlicer(simData, fieldData)
-        filename = 'opsimslicer_test.npz'
-        self.filenames.append(filename)
-        slicer.writeData(filename, metricValues)
-        metricBack, slicerBack, header = self.baseslicer.readData(filename)
+        with lsst.utils.tests.getTempFilePath(".npz") as filename:
+            slicer.writeData(filename, metricValues)
+            metricBack, slicerBack, header = self.baseslicer.readData(filename)
         assert(slicer == slicerBack)
         np.testing.assert_almost_equal(metricBack, metricValues)
         attr2check = ['nslice', 'columnsNeeded', 'lonCol', 'latCol', 'simDataFieldIDColName']
@@ -120,11 +114,10 @@ class TestSlicers(unittest.TestCase):
         data = np.zeros(1, dtype=[('testdata', 'float')])
         data[:] = np.random.rand(1)
         slicer.setupSlicer(data)
-        filename = 'unislicer_test.npz'
-        self.filenames.append(filename)
-        metricValue = np.array([25.])
-        slicer.writeData(filename, metricValue)
-        dataBack, slicerBack, header = self.baseslicer.readData(filename)
+        with lsst.utils.tests.getTempFilePath(".npz") as filename:
+            metricValue = np.array([25.])
+            slicer.writeData(filename, metricValue)
+            dataBack, slicerBack, header = self.baseslicer.readData(filename)
         assert(slicer == slicerBack)
         np.testing.assert_almost_equal(dataBack, metricValue)
         attr2check = ['nslice', 'columnsNeeded']
@@ -139,10 +132,9 @@ class TestSlicers(unittest.TestCase):
         for i, ack in enumerate(data):
             n_el = np.random.rand(1)*4  # up to 4 elements
             data[i] = np.arange(n_el)
-        filename = 'heal_complex.npz'
-        self.filenames.append(filename)
-        slicer.writeData(filename, data)
-        dataBack, slicerBack, header = self.baseslicer.readData(filename)
+        with lsst.utils.tests.getTempFilePath(".npz") as filename:
+            slicer.writeData(filename, data)
+            dataBack, slicerBack, header = self.baseslicer.readData(filename)
         assert(slicer == slicerBack)
         # This is a crazy slow loop!
         for i, ack in enumerate(data):
@@ -156,19 +148,14 @@ class TestSlicers(unittest.TestCase):
         dv = np.core.records.fromarrays(data, names=colnames)
         slicer = slicers.NDSlicer(colnames, binsList=10)
         slicer.setupSlicer(dv)
-        filename = 'nDSlicer_test.npz'
-        self.filenames.append(filename)
-        metricdata = np.zeros(slicer.nslice, dtype='float')
-        for i, s in enumerate(slicer):
-            metricdata[i] = i
-        slicer.writeData(filename, metricdata)
-        dataBack, slicerBack, header = self.baseslicer.readData(filename)
+        with lsst.utils.tests.getTempFilePath(".npz") as filename:
+            metricdata = np.zeros(slicer.nslice, dtype='float')
+            for i, s in enumerate(slicer):
+                metricdata[i] = i
+            slicer.writeData(filename, metricdata)
+            dataBack, slicerBack, header = self.baseslicer.readData(filename)
         assert(slicer == slicerBack)
         np.testing.assert_almost_equal(dataBack, metricdata)
-
-    def tearDown(self):
-        for filename in self.filenames:
-            os.remove(filename)
 
 
 class TestMemory(lsst.utils.tests.MemoryTestCase):

--- a/ups/sims_maf.table
+++ b/ups/sims_maf.table
@@ -18,6 +18,8 @@ setupRequired(sims_photUtils)
 # For unit conversions
 setupRequired(sims_coordUtils)
 # For the dustmaps and stellar density maps
+setupRequired(sims_data)
+# For unit testing
 setupRequired(sims_maps)
 # For camera footprint
 setupRequired(obs_lsstSim)


### PR DESCRIPTION
Using fixed names in multiple tests creates problems with
multi-process testing.