### PR TITLE
Changed self.stype to np.str_ in resultsDb.py

### DIFF
--- a/python/lsst/sims/maf/db/resultsDb.py
+++ b/python/lsst/sims/maf/db/resultsDb.py
@@ -151,7 +151,7 @@ class ResultsDb(object):
         except DatabaseError:
             raise ValueError("Cannot create a %s database at %s. Check directory exists." %(self.driver, self.database))
         self.slen = 1024
-        self.stype = 'S%d' % (self.slen)
+        self.stype = (np.str_, self.slen)
 
     def close(self):
         """


### PR DESCRIPTION
Before, it was "|S%d", which caused showMaf.py to fail for me on python3