### PR TITLE
Added hourglass batch and run script

### DIFF
--- a/bin.src/run_hourglass.py
+++ b/bin.src/run_hourglass.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import argparse
+import matplotlib
+matplotlib.use('Agg')
+import lsst.sims.maf.batches as batches
+from run_generic import *
+
+
+def setBatches(opsdb, colmap, args):
+    bdict = {}
+    bdict.update(batches.hourglassBatch(colmap, args.runName,
+                                        nyears=args.nyears, extraSql=args.sqlConstraint))
+    return bdict
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Run or replot a set of metric bundles.")
+    parser.add_argument("--nyears", type=int, default=10, help="Number of years to create Hourglass plots.")
+
+    args = parseArgs('hourglass', parser=parser)
+    opsdb, colmap = connectDb(args.dbfile)
+    bdict = setBatches(opsdb, colmap, args)
+    if args.plotOnly:
+        raise ValueError('Cannot replot hourglass metric data, as it is not saved to disk.')
+    else:
+        run(bdict, opsdb, colmap, args)
+    opsdb.close()

--- a/python/lsst/sims/maf/batches/__init__.py
+++ b/python/lsst/sims/maf/batches/__init__.py
@@ -5,4 +5,5 @@ from .slewBatch import *
 from .timeBatch import *
 from .metadataBatch import *
 from .visitdepthBatch import *
+from .hourglassBatch import *
 from .glanceBatch import *

--- a/python/lsst/sims/maf/batches/glanceBatch.py
+++ b/python/lsst/sims/maf/batches/glanceBatch.py
@@ -8,6 +8,7 @@ import lsst.sims.maf.metricBundles as metricBundles
 from .colMapDict import ColMapDict
 from .common import standardSummary
 from .slewBatch import slewBasics
+from .hourglassBatch import hourglassBatch
 
 __all__ = ['glanceBatch']
 
@@ -188,18 +189,11 @@ def glanceBatch(colmap=None, runName='opsim',
                                         displayDict=displayDict)
     bundleList.append(bundle)
 
-    years = list(range(nyears+1))
-    displayDict = {'group': 'Hourglass'}
-    for year in years[1:]:
-        sql = 'night > %i and night <= %i' % (365.25*(year-1), 365.25*year)
-        slicer = slicers.HourglassSlicer()
-        metric = metrics.HourglassMetric(nightCol=colmap['night'], mjdCol=colmap['mjd'])
-        metadata = 'Year %i-%i' % (year-1, year)
-        bundle = metricBundles.MetricBundle(metric, slicer, sql, metadata=metadata, displayDict=displayDict)
-        bundleList.append(bundle)
-
     for b in bundleList:
         b.setRunName(runName)
+
+    # Add hourglass plots.
+    hrDict = hourglassBatch(colmap=colmap, runName=runName, nyears=nyears, extraSql=sqlConstraint)
 
     # Add basic slew stats.
     try:
@@ -209,5 +203,6 @@ def glanceBatch(colmap=None, runName='opsim',
 
     bd = metricBundles.makeBundlesDictFromList(bundleList)
     bd.update(slewDict)
+    bd.update(hrDict)
     return bd
 

--- a/python/lsst/sims/maf/batches/hourglassBatch.py
+++ b/python/lsst/sims/maf/batches/hourglassBatch.py
@@ -1,0 +1,65 @@
+"""Run the hourglass metric.
+"""
+import lsst.sims.maf.metrics as metrics
+import lsst.sims.maf.slicers as slicers
+import lsst.sims.maf.stackers as stackers
+import lsst.sims.maf.plots as plots
+import lsst.sims.maf.metricBundles as mb
+from .colMapDict import ColMapDict
+from .common import standardSummary
+
+__all__ = ['hourglassBatch']
+
+def hourglassBatch(colmap=None, runName='opsim', nyears=10, extraSql=None, extraMetadata=None):
+    """Run the hourglass metric, for each individual year.
+
+    Parameters
+    ----------
+    colmap : dict, opt
+        A dictionary with a mapping of column names. Default will use OpsimV4 column names.
+    run_name : str, opt
+        The name of the simulated survey. Default is "opsim".
+    nyears : int (10), opt
+        How many years to attempt to make hourglass plots for. Default is 10.
+    extraSql : str, opt
+        Add an extra sql constraint before running metrics. Default None.
+    extraMetadata : str, opt
+        Add an extra piece of metadata before running metrics. Default None.
+    """
+    if colmap is None:
+        colmap = ColMapDict('opsimV4')
+    bundleList = []
+
+    sql = ''
+    metadata = ''
+    # Add additional sql constraint (such as wfdWhere) and metadata, if provided.
+    if (extraSql is not None) and (len(extraSql) > 0):
+        sql = extraSql
+        if extraMetadata is None:
+            metadata = extraSql.replace('filter =', '').replace('filter=', '')
+            metadata = metadata.replace('"', '').replace("'", '')
+    if extraMetadata is not None:
+        metadata = extraMetadata
+
+    years = list(range(nyears + 1))
+    displayDict = {'group': 'Hourglass'}
+    for year in years[1:]:
+        displayDict['subgroup'] = 'Year %d' % year
+        displayDict['caption'] = 'Visualization of the filter usage of the telescope. ' \
+                                 'The black wavy line indicates lunar phase; the red and blue ' \
+                                 'solid lines indicate nautical and civil twilight.'
+        sqlconstraint = 'night > %i and night <= %i' % (365.25 * (year - 1), 365.25 * year)
+        if len(sql) > 0:
+            sqlconstraint = '(%s) and (%s)' % (sqlconstraint, sql)
+        md = metadata + ' year %i-%i' % (year - 1, year)
+        slicer = slicers.HourglassSlicer()
+        metric = metrics.HourglassMetric(nightCol=colmap['night'], mjdCol=colmap['mjd'],
+                                         metricName='Hourglass')
+        bundle = mb.MetricBundle(metric, slicer, constraint=sqlconstraint, metadata=md,
+                                 displayDict=displayDict)
+        bundleList.append(bundle)
+
+    # Set the runName for all bundles and return the bundleDict.
+    for b in bundleList:
+        b.setRunName(runName)
+    return mb.makeBundlesDictFromList(bundleList)

--- a/python/lsst/sims/maf/metrics/hourglassMetric.py
+++ b/python/lsst/sims/maf/metrics/hourglassMetric.py
@@ -49,7 +49,8 @@ class HourglassMetric(BaseMetric):
         moon = ephem.Moon()
         for h in horizons:
             obs = ephem.Observer()
-            obs.lat, obs.lon, obs.elevation = self.telescope.latitude_rad, self.telescope.longitude_rad, self.telescope.height
+            obs.lat, obs.lon, obs.elevation = self.telescope.latitude_rad, self.telescope.longitude_rad, \
+                                              self.telescope.height
             obs.horizon = h
             obsList.append(obs)
 
@@ -70,9 +71,11 @@ class HourglassMetric(BaseMetric):
                 pernight[key[j]+'_set'][i] = obs.previous_setting(S, start=pernight['midnight'][i]-doff,
                                                                   use_center=True) + doff
 
-        # Define the breakpoints as where either the filter changes OR there's more than a 2 minute gap in observing
+        # Define the breakpoints as where either the filter changes OR
+        # there's more than a 2 minute gap in observing
         good = np.where((dataSlice[self.filterCol] != np.roll(dataSlice[self.filterCol], 1)) |
-                        (np.abs(np.roll(dataSlice[self.mjdCol], 1)-dataSlice[self.mjdCol]) > 120./3600./24.))[0]
+                        (np.abs(np.roll(dataSlice[self.mjdCol], 1) -
+                                dataSlice[self.mjdCol]) > 120./3600./24.))[0]
         good = np.concatenate((good, [0], [len(dataSlice[self.filterCol])]))
         good = np.unique(good)
         left = good[:-1]


### PR DESCRIPTION
Add a batch to calculate the hourglass metric and plots for each year. 
Pretty much copied @yoachim's hourglass setup from glanceBatch into hourglassBatch. 
Now it can be run quickly/separately. 

I have run this on v4 opsim runs (both run_hourglass.py and run_glance.py) without problems. 