### PR TITLE
add batch for filter change metrics

### DIFF
--- a/bin.src/run_all.py
+++ b/bin.src/run_all.py
@@ -37,6 +37,10 @@ def setBatches(opsdb, colmap, args):
     bdict.update(batches.tEffMetrics(colmap, args.runName,
                                      extraSql=sqltags['WFD'], extraMetadata='WFD'))
     bdict.update(batches.slewBasics(colmap, args.runName))
+    
+    # Whole survey filter changes
+    bdict.update(batches.nfilterChanges(colmap, args.runName))
+
     return bdict
 
 

--- a/bin.src/run_all.py
+++ b/bin.src/run_all.py
@@ -37,9 +37,9 @@ def setBatches(opsdb, colmap, args):
     bdict.update(batches.tEffMetrics(colmap, args.runName,
                                      extraSql=sqltags['WFD'], extraMetadata='WFD'))
     bdict.update(batches.slewBasics(colmap, args.runName))
-    
+
     # Whole survey filter changes
-    bdict.update(batches.nfilterChanges(colmap, args.runName))
+    bdict.update(batches.filtersWholeSurveyBatch(colmap, args.runName))
 
     return bdict
 

--- a/bin.src/run_filterchanges.py
+++ b/bin.src/run_filterchanges.py
@@ -14,11 +14,9 @@ def setBatches(opsdb, colmap, args):
     propids, proptags, sqltags = setSQL(opsdb, sqlConstraint=args.sqlConstraint)
 
     # Per Night filter changes
-    # bdict.update(batches.nfilterChanges(colmap, args.runName, binNights=1))
     bdict.update(batches.filtersPerNightBatch(colmap, args.runName))
 
     # Whole survey filter changes
-    # bdict.update(batches.nfilterChanges(colmap, args.runName))
     bdict.update(batches.filtersWholeSurveyBatch(colmap, args.runName))
 
     return bdict

--- a/bin.src/run_filterchanges.py
+++ b/bin.src/run_filterchanges.py
@@ -14,10 +14,12 @@ def setBatches(opsdb, colmap, args):
     propids, proptags, sqltags = setSQL(opsdb, sqlConstraint=args.sqlConstraint)
 
     # Per Night filter changes
-    bdict.update(batches.nfilterChanges(colmap, args.runName, binNights=1))
+    # bdict.update(batches.nfilterChanges(colmap, args.runName, binNights=1))
+    bdict.update(batches.filtersPerNightBatch(colmap, args.runName))
 
     # Whole survey filter changes
-    bdict.update(batches.nfilterChanges(colmap, args.runName))
+    # bdict.update(batches.nfilterChanges(colmap, args.runName))
+    bdict.update(batches.filtersWholeSurveyBatch(colmap, args.runName))
 
     return bdict
 

--- a/bin.src/run_filterchanges.py
+++ b/bin.src/run_filterchanges.py
@@ -11,13 +11,10 @@ from run_generic import *
 def setBatches(opsdb, colmap, args):
     bdict = {}
 
-    propids, proptags, sqltags = setSQL(opsdb, sqlConstraint=args.sqlConstraint)
-
     # Per Night filter changes
-    bdict.update(batches.filtersPerNightBatch(colmap, args.runName))
-
+    bdict.update(batches.filtersPerNightBatch(colmap, args.runName, nights=1))
     # Whole survey filter changes
-    bdict.update(batches.filtersWholeSurveyBatch(colmap, args.runName))
+    bdict.update(batches.filtersAllNightsBatch(colmap, args.runName))
 
     return bdict
 

--- a/bin.src/run_filterchanges.py
+++ b/bin.src/run_filterchanges.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import matplotlib
+matplotlib.use('Agg')
+import lsst.sims.maf.batches as batches
+from run_generic import *
+
+
+def setBatches(opsdb, colmap, args):
+    bdict = {}
+
+    propids, proptags, sqltags = setSQL(opsdb, sqlConstraint=args.sqlConstraint)
+
+    # Per Night filter changes
+    bdict.update(batches.nfilterChanges(colmap, args.runName, binNights=1))
+
+    # Whole survey filter changes
+    bdict.update(batches.nfilterChanges(colmap, args.runName))
+
+    return bdict
+
+
+if __name__ == '__main__':
+    args = parseArgs(subdir = 'filterchange')
+    opsdb, colmap = connectDb(args.dbfile)
+    bdict = setBatches(opsdb, colmap, args)
+    if args.plotOnly:
+        replot(bdict, opsdb, colmap, args)
+    else:
+        run(bdict, opsdb, colmap, args)
+    opsdb.close()

--- a/python/lsst/sims/maf/batches/__init__.py
+++ b/python/lsst/sims/maf/batches/__init__.py
@@ -6,3 +6,4 @@ from .timeBatch import *
 from .metadataBatch import *
 from .visitdepthBatch import *
 from .glanceBatch import *
+from .filterchangeBatch import *

--- a/python/lsst/sims/maf/batches/filterchangeBatch.py
+++ b/python/lsst/sims/maf/batches/filterchangeBatch.py
@@ -1,49 +1,41 @@
 import lsst.sims.maf.metrics as metrics
 import lsst.sims.maf.slicers as slicers
-import lsst.sims.maf.plots as plots
 import lsst.sims.maf.metricBundles as mb
-from .colMapDict import ColMapDict, getColMap
+from .colMapDict import ColMapDict
 from .common import standardSummary
 
-__all__ = ['filtersPerNightBatch','filtersWholeSurveyBatch']
+__all__ = ['filtersPerNightBatch','filtersAllNightsBatch']
 
-def setupSlicer(binNights=None):
-    if binNights is None:
-        # Setup slicer, summaryStats, and captions for metrics over the entire survey.
-        metadata = ['Whole survey']
-        subgroup = 'Whole Survey'
-        slicer = slicers.UniSlicer()
-        summaryStats = None
-        captionDict = {'NChanges': 'Total filter changes over survey',
-                       'MinTime': 'Minimum time between filter changes, in minutes.',
-                       'NFaster10':'Number of filter changes faster than 10 minutes over the entire survey.',
-                       'NFaster20':'Number of filter changes faster than 10 minutes over the entire survey.',
-                       'Maxin10':'Max number of filter changes within a window of 10 minutes over the entire survey.',
-                       'Maxin20':'Max number of filter changes within a window of 20 minutes over the entire survey.'}
-        metricName='Total Filter Changes'
 
+def setupMetrics(colmap, wholesurvey=False):
+    metricList = []
+    captionList = []
+    # Number of filter changes (per slice - either whole survey or X nights)
+    if wholesurvey:
+        metricList.append(metrics.NChangesMetric(col=colmap['filter'], metricName='Total Filter Changes'))
     else:
-        # Setup slicer, summaryStats, and captions for metrics on a per night basis.
-        if binNights == 1:
-            metadata = ['Per Night']
-        else:
-            metedata = ['Per %.1f Nights' % (binNights)]
-        subgroup = 'Per Night'
-        slicer = slicers.OneDSlicer(sliceColName='night', binsize=binNights)
-        summaryStats = standardSummary()
-        captionDict = {'NChanges': 'Number of filter changes per night.',
-                       'MinTime': 'Minimum time between filter changes, in minutes, per night',
-                       'NFaster10':'Number of filter changes faster than 10 minutes, per night.',
-                       'NFaster20':'Number of filter changes faster than 20 minutes, per night.',
-                       'Maxin10': 'Max number of filter changes within a window of 10 minutes, per night.',
-                       'Maxin20':'Max number of filter changes within a window of 10 minutes, per night.'}
-        metricName='Filter Changes'
+        metricList.append(metrics.NChangesMetric(col=colmap['filter'], metricName='Filter Changes'))
+    captionList.append('Total filter changes ')
+    # Minimum time between filter changes
+    metricList.append(metrics.MinTimeBetweenStatesMetric(changeCol=colmap['filter']))
+    captionList.append('Minimum time between filter changes ')
+    # Number of filter changes faster than 10 minutes
+    metricList.append(metrics.NStateChangesFasterThanMetric(changeCol=colmap['filter'], cutoff=10))
+    captionList.append('Number of filter changes faster than 10 minutes ')
+    # Number of filter changes faster than 20 minutes
+    metricList.append(metrics.NStateChangesFasterThanMetric(changeCol=colmap['filter'], cutoff=20))
+    captionList.append('Number of filter changes faster than 20 minutes ')
+    # Maximum number of filter changes faster than 10 minutes within slice
+    metricList.append(metrics.MaxStateChangesWithinMetric(changeCol=colmap['filter'], timespan=10))
+    captionList.append('Max number of filter  changes within a window of 10 minutes ')
+    # Maximum number of filter changes faster than 20 minutes within slice
+    metricList.append(metrics.MaxStateChangesWithinMetric(changeCol=colmap['filter'], timespan=20))
+    captionList.append('Max number of filter changes within a window of 20 minutes ')
+    return metricList, captionList
 
-    return metadata,subgroup,slicer,summaryStats,captionDict,metricName
 
-def nfilterChanges(colmap=None, runName='opsim', binNights=None, extraSql=None, extraMetadata=None):
-
-    """Generate a set of metrics measuring the number and rate of filter changes.
+def filtersPerNightBatch(colmap=None, runName='opsim', nights=1, extraSql=None, extraMetadata=None):
+    """Generate a set of metrics measuring the number and rate of filter changes over a given span of nights.
 
     Parameters
     ----------
@@ -51,9 +43,8 @@ def nfilterChanges(colmap=None, runName='opsim', binNights=None, extraSql=None, 
         A dictionary with a mapping of column names. Default will use OpsimV4 column names.
     run_name : str, opt
         The name of the simulated survey. Default is "opsim".
-    binNights : int, opt
-        Size of night bin to use when calculating metrics. If left None, metrics
-        will be calculated over the entire survey
+    nights : int, opt
+        Size of night bin to use when calculating metrics.  Default is 1.
     extraSql : str, opt
         Additional constraint to add to any sql constraints (e.g. 'propId=1' or 'fieldID=522').
         Default None, for no additional constraints.
@@ -69,93 +60,90 @@ def nfilterChanges(colmap=None, runName='opsim', binNights=None, extraSql=None, 
         colmap = ColMapDict('opsimV4')
     bundleList = []
 
-    # Set up basic all and per filter sql constraints.
-    sqlconstraints = ['']
-
-    metadata, subgroup, slicer, summaryStats, captionDict, metricName = setupSlicer(binNights)
-    displayDict = {'group': 'Filter Changes', 'subgroup': subgroup}
-
-    # Add additional sql constraint (such as wfdWhere) and metadata, if provided.
+    # Set up sql and metadata, if passed any additional information.
+    sql = ''
+    metadata = 'Per '
+    if nights == 1:
+        metadata += ' Night'
+    else:
+        metadata += ' %s Nights' % nights
+    metacaption = metadata.lower()
     if (extraSql is not None) and (len(extraSql) > 0):
-        tmp = []
-        for s in sqlconstraints:
-            if len(s) == 0:
-                tmp.append(extraSql)
-            else:
-                tmp.append('%s and (%s)' % (s, extraSql))
-        sqlconstraints = tmp
+        sql = extraSql
         if extraMetadata is None:
-            metadata = ['%s %s' % (extraSql, m) for m in metadata]
+            metadata += ' %s' % extraSql
+            metacaption += ', with %s selection' % extraSql
     if extraMetadata is not None:
-        metadata = ['%s %s' % (extraMetadata, m) for m in metadata]
-    metadataCaption = extraMetadata
-    if metadataCaption is None:
-        metadataCaption = 'all visits'
+        metadata += ' %s' % extraMetadata
+        metacaption += ', %s only' % extraMetadata
+    metacaption += '.'
 
-    for sql, meta in zip(sqlconstraints, metadata):
 
-        # Number of filter changes
-        metric = metrics.NChangesMetric(col='filter', metricName=metricName)
-        plotDict = {'ylabel': 'Number of Filter Changes'}
-        displayDict['caption'] = captionDict['NChanges']
-        bundle = mb.MetricBundle(metric, slicer, sql, plotDict=plotDict,
-                                            displayDict=displayDict, runName=runName, metadata=meta,
-                                            summaryMetrics=summaryStats)
-        bundleList.append(bundle)
+    displayDict = {'group': 'Filter Changes', 'subgroup': metadata}
+    summaryStats = standardSummary()
 
-        # Minimum time between filter changes (minutes)
-        metric = metrics.MinTimeBetweenStatesMetric(changeCol='filter')
-        plotDict = {'yMin': 0, 'yMax': 120}
-        displayDict['caption'] = captionDict['MinTime']
-        bundle = mb.MetricBundle(metric, slicer, sql, plotDict=plotDict,
-                                            displayDict=displayDict, runName=runName, metadata=meta,
-                                            summaryMetrics=summaryStats)
-        bundleList.append(bundle)
-
-        # N Filter changes faster than 10 minutes
-        metric = metrics.NStateChangesFasterThanMetric(changeCol='filter', cutoff=10)
-        plotDict = {}
-        displayDict['caption'] = captionDict['NFaster10']
-        bundle = mb.MetricBundle(metric, slicer, sql, plotDict=plotDict,
-                                            displayDict=displayDict, runName=runName, metadata=meta,
-                                            summaryMetrics=summaryStats)
-        bundleList.append(bundle)
-
-        # N Filter changes faster than 20 minutes
-        displayDict['caption'] = captionDict['NFaster20']
-        metric = metrics.NStateChangesFasterThanMetric(changeCol='filter', cutoff=20)
-        plotDict = {}
-        bundle = mb.MetricBundle(metric, slicer, sql, plotDict=plotDict,
-                                            displayDict=displayDict, runName=runName, metadata=meta,
-                                            summaryMetrics=summaryStats)
-        bundleList.append(bundle)
-
-        # Max N Filter changes faster than 10 minutes
-        metric = metrics.MaxStateChangesWithinMetric(changeCol='filter', timespan=10)
-        plotDict = {}
-        displayDict['caption'] = captionDict['Maxin10']
-        bundle = mb.MetricBundle(metric, slicer, sql, plotDict=plotDict,
-                                            displayDict=displayDict, runName=runName, metadata=meta,
-                                            summaryMetrics=summaryStats)
-        bundleList.append(bundle)
-
-        # Max N Filter changes faster than 20 minutes
-        metric = metrics.MaxStateChangesWithinMetric(changeCol='filter', timespan=20)
-        plotDict = {}
-        displayDict['caption'] = captionDict['Maxin20']
-        bundle = mb.MetricBundle(metric, slicer, sql, plotDict=plotDict,
-                                            displayDict=displayDict, runName=runName, metadata=meta,
-                                            summaryMetrics=summaryStats)
+    slicer = slicers.OneDSlicer(sliceColName=colmap['night'], binsize=nights)
+    metricList, captionList = setupMetrics(colmap)
+    for m, caption in zip(metricList, captionList):
+        displayDict['caption'] = caption + metacaption
+        bundle = mb.MetricBundle(m, slicer, sql, runName=runName, metadata=metadata,
+                                 displayDict=displayDict,
+                                 summaryMetrics=summaryStats)
         bundleList.append(bundle)
 
     for b in bundleList:
         b.setRunName(runName)
     return mb.makeBundlesDictFromList(bundleList)
 
-def filtersPerNightBatch(colmap=None, runName='opsim',extraSql=None, extraMetadata=None):
-    return nfilterChanges(colmap=colmap, binNights=1.0, runName=runName,
-                          extraSql=extraSql, extraMetadata=extraMetadata)
 
-def filtersWholeSurveyBatch(colmap=None, runName='opsim',extraSql=None, extraMetadata=None):
-    return nfilterChanges(colmap=colmap, binNights=None, runName=runName,
-                          extraSql=extraSql, extraMetadata=extraMetadata)
+def filtersAllNightsBatch(colmap=None, runName='opsim', extraSql=None, extraMetadata=None):
+    """Generate a set of metrics measuring the number and rate of filter changes over the entire survey.
+
+    Parameters
+    ----------
+    colmap : dict, opt
+        A dictionary with a mapping of column names. Default will use OpsimV4 column names.
+    run_name : str, opt
+        The name of the simulated survey. Default is "opsim".
+    extraSql : str, opt
+        Additional constraint to add to any sql constraints (e.g. 'propId=1' or 'fieldID=522').
+        Default None, for no additional constraints.
+    extraMetadata : str, opt
+        Additional metadata to add before any below (i.e. "WFD").  Default is None.
+
+    Returns
+    -------
+    metricBundleDict
+    """
+    if colmap is None:
+        colmap = ColMapDict('opsimV4')
+    bundleList = []
+
+    # Set up sql and metadata, if passed any additional information.
+    sql = ''
+    metadata = 'Whole Survey'
+    metacaption = 'over the whole survey'
+    if (extraSql is not None) and (len(extraSql) > 0):
+        sql = extraSql
+        if extraMetadata is None:
+            metadata += ' %s' % extraSql
+            metacaption += ', with %s selction' % extraSql
+    if extraMetadata is not None:
+        metadata += ' %s' % extraMetadata
+        metacaption += ', %s only' % (extraMetadata)
+    metacaption += '.'
+
+
+    displayDict = {'group': 'Filter Changes', 'subgroup': metadata}
+
+    slicer = slicers.UniSlicer()
+    metricList, captionList = setupMetrics(colmap)
+    for m, caption in zip(metricList, captionList):
+        displayDict['caption'] = caption + metacaption
+        bundle = mb.MetricBundle(m, slicer, sql, runName=runName, metadata=metadata,
+                                 displayDict=displayDict)
+        bundleList.append(bundle)
+
+    for b in bundleList:
+        b.setRunName(runName)
+    return mb.makeBundlesDictFromList(bundleList)

--- a/python/lsst/sims/maf/batches/filterchangeBatch.py
+++ b/python/lsst/sims/maf/batches/filterchangeBatch.py
@@ -1,0 +1,152 @@
+import lsst.sims.maf.metrics as metrics
+import lsst.sims.maf.slicers as slicers
+import lsst.sims.maf.plots as plots
+import lsst.sims.maf.metricBundles as mb
+from .colMapDict import ColMapDict, getColMap
+from .common import standardSummary
+
+__all__ = ['nfilterChanges']
+
+def nfilterChanges(colmap=None, runName='opsim', binNights=None, extraSql=None, extraMetadata=None):
+
+    """Generate a set of metrics measuring the number and rate of filter changes.
+
+    Parameters
+    ----------
+    colmap : dict, opt
+        A dictionary with a mapping of column names. Default will use OpsimV4 column names.
+    run_name : str, opt
+        The name of the simulated survey. Default is "opsim".
+    binNights : int, opt
+        Size of night bin to use when calculating metrics. If left None, metrics
+        will be calculated over the entire survey
+    extraSql : str, opt
+        Additional constraint to add to any sql constraints (e.g. 'propId=1' or 'fieldID=522').
+        Default None, for no additional constraints.
+    extraMetadata : str, opt
+        Additional metadata to add before any below (i.e. "WFD").  Default is None.
+
+    Returns
+    -------
+    metricBundleDict
+    """
+
+    if colmap is None:
+        colmap = ColMapDict('opsimV4')
+    bundleList = []
+
+    # Set up basic all and per filter sql constraints.
+    sqlconstraints = ['']
+
+    if binNights is not None:
+        if binNights == 1:
+            metadata = ['Per Night']
+        else:
+            metedata = ['Per %.1f Nights' % (binNights)]
+        subgroup = 'Per Night'
+    else:
+        metadata = ['Whole survey']
+        subgroup = 'Whole Survey'
+
+    # Add additional sql constraint (such as wfdWhere) and metadata, if provided.
+    if (extraSql is not None) and (len(extraSql) > 0):
+        tmp = []
+        for s in sqlconstraints:
+            if len(s) == 0:
+                tmp.append(extraSql)
+            else:
+                tmp.append('%s and (%s)' % (s, extraSql))
+        sqlconstraints = tmp
+        if extraMetadata is None:
+            metadata = ['%s %s' % (extraSql, m) for m in metadata]
+    if extraMetadata is not None:
+        metadata = ['%s %s' % (extraMetadata, m) for m in metadata]
+    metadataCaption = extraMetadata
+    if metadataCaption is None:
+        metadataCaption = 'all visits'
+
+    group = 'Filter Changes'
+    if binNights is None:
+        # Setup slicer, summaryStats, and captions for metrics over the entire survey.
+        slicer = slicers.UniSlicer()
+        summaryStats = None
+        captionDict = {'NChanges': 'Total filter changes over survey',
+                       'MinTime': 'Minimum time between filter changes, in minutes.',
+                       'NFaster10':'Number of filter changes faster than 10 minutes over the entire survey.',
+                       'NFaster20':'Number of filter changes faster than 10 minutes over the entire survey.',
+                       'Maxin10':'Max number of filter changes within a window of 10 minutes over the entire survey.',
+                       'Maxin20':'Max number of filter changes within a window of 20 minutes over the entire survey.'}
+        metricName='Total Filter Changes'
+
+    else:
+        # Setup slicer, summaryStats, and cpations for metrics on a per night basis.
+        slicer = slicers.OneDSlicer(sliceColName='night', binsize=binNights)
+        summaryStats = standardSummary()
+        captionDict = {'NChanges': 'Number of filter changes per night.',
+                       'MinTime': 'Minimum time between filter changes, in minutes, per night',
+                       'NFaster10':'Number of filter changes faster than 10 minutes, per night.',
+                       'NFaster20':'Number of filter changes faster than 20 minutes, per night.',
+                       'Maxin10': 'Max number of filter changes within a window of 10 minutes, per night.',
+                       'Maxin20':'Max number of filter changes within a window of 10 minutes, per night.'}
+        metricName='Filter Changes'
+
+    displayDict = {'group': 'Filter Changes', 'subgroup': subgroup}
+    for sql, meta in zip(sqlconstraints, metadata):
+
+        # Number of filter changes
+        metric = metrics.NChangesMetric(col='filter', metricName=metricName)
+        plotDict = {'ylabel': 'Number of Filter Changes'}
+        displayDict['caption'] = captionDict['NChanges']
+        bundle = mb.MetricBundle(metric, slicer, sql, plotDict=plotDict,
+                                            displayDict=displayDict, runName=runName, metadata=meta,
+                                            summaryMetrics=summaryStats)
+        bundleList.append(bundle)
+
+        # Minimum time between filter changes (minutes)
+        metric = metrics.MinTimeBetweenStatesMetric(changeCol='filter')
+        plotDict = {'yMin': 0, 'yMax': 120}
+        displayDict['caption'] = captionDict['MinTime']
+        bundle = mb.MetricBundle(metric, slicer, sql, plotDict=plotDict,
+                                            displayDict=displayDict, runName=runName, metadata=meta,
+                                            summaryMetrics=summaryStats)
+        bundleList.append(bundle)
+
+        # N Filter changes faster than 10 minutes
+        metric = metrics.NStateChangesFasterThanMetric(changeCol='filter', cutoff=10)
+        plotDict = {}
+        displayDict['caption'] = captionDict['NFaster10']
+        bundle = mb.MetricBundle(metric, slicer, sql, plotDict=plotDict,
+                                            displayDict=displayDict, runName=runName, metadata=meta,
+                                            summaryMetrics=summaryStats)
+        bundleList.append(bundle)
+
+        # N Filter changes faster than 20 minutes
+        displayDict['caption'] = captionDict['NFaster20']
+        metric = metrics.NStateChangesFasterThanMetric(changeCol='filter', cutoff=20)
+        plotDict = {}
+        bundle = mb.MetricBundle(metric, slicer, sql, plotDict=plotDict,
+                                            displayDict=displayDict, runName=runName, metadata=meta,
+                                            summaryMetrics=summaryStats)
+        bundleList.append(bundle)
+
+        # Max N Filter changes faster than 10 minutes
+        metric = metrics.MaxStateChangesWithinMetric(changeCol='filter', timespan=10)
+        plotDict = {}
+        displayDict['caption'] = captionDict['Maxin10']
+        bundle = mb.MetricBundle(metric, slicer, sql, plotDict=plotDict,
+                                            displayDict=displayDict, runName=runName, metadata=meta,
+                                            summaryMetrics=summaryStats)
+        bundleList.append(bundle)
+
+        # Max N Filter changes faster than 20 minutes
+        metric = metrics.MaxStateChangesWithinMetric(changeCol='filter', timespan=20)
+        plotDict = {}
+        displayDict['caption'] = captionDict['Maxin20']
+        bundle = mb.MetricBundle(metric, slicer, sql, plotDict=plotDict,
+                                            displayDict=displayDict, runName=runName, metadata=meta,
+                                            summaryMetrics=summaryStats)
+        bundleList.append(bundle)
+
+    for b in bundleList:
+        b.setRunName(runName)
+    return mb.makeBundlesDictFromList(bundleList)

--- a/python/lsst/sims/maf/metrics/technicalMetrics.py
+++ b/python/lsst/sims/maf/metrics/technicalMetrics.py
@@ -39,9 +39,9 @@ class MinTimeBetweenStatesMetric(BaseMetric):
         self.changeCol = changeCol
         self.timeCol = timeCol
         if metricName is None:
-            metricName = 'Minimum time between %s changes minutes' % (changeCol)
+            metricName = 'Minimum time between %s changes (minutes)' % (changeCol)
         super(MinTimeBetweenStatesMetric, self).__init__(col=[changeCol, timeCol], metricName=metricName,
-                                                         units='minutes', **kwargs)
+                                                         units='', **kwargs)
 
     def run(self, dataSlice, slicePoint=None):
         # Sort on time, to be sure we've got filter (or other col) changes in the right order.


### PR DESCRIPTION
This is a relatively small pull request to add a new batch to generate the filter change metrics from the `schedulerValidation.py` script. For now I have only have not added this new batch to the `run_all.py` script, but I did add `run_filterchanges.py` so the batch can be run separately.