### PR TITLE
Added rotational dither stacker to MAF

### DIFF
--- a/python/lsst/sims/maf/stackers/baseStacker.py
+++ b/python/lsst/sims/maf/stackers/baseStacker.py
@@ -27,7 +27,8 @@ class StackerRegistry(type):
                 modname = modname + '.'
         stackername = modname + name
         if stackername in cls.registry:
-            raise Exception('Redefining stacker %s! (there are >1 stackers with the same name)' %(stackername))
+            raise Exception('Redefining stacker %s! (there are >1 stackers with the same name)'
+                            % (stackername))
         if stackername != 'BaseStacker':
             cls.registry[stackername] = cls
 
@@ -146,7 +147,7 @@ class BaseStacker(with_metaclass(StackerRegistry, object)):
             warnings.warn('Please update the stacker %s so that the _run method matches the current API. '
                           'This will give you the option to skip re-running stackers if the columns are '
                           'already present.'
-                          % (self.__class__.__name__ ))
+                          % (self.__class__.__name__))
             return self._run(simData)
 
     def _run(self, simData, cols_present=False):

--- a/python/lsst/sims/maf/stackers/coordStackers.py
+++ b/python/lsst/sims/maf/stackers/coordStackers.py
@@ -7,6 +7,7 @@ from .ditherStackers import wrapRA
 
 __all__ = ['mjd2djd', 'raDec2AltAz', 'GalacticStacker', 'EclipticStacker']
 
+
 def mjd2djd(mjd):
     """Convert MJD to the Dublin Julian date used by ephem.
 
@@ -22,6 +23,7 @@ def mjd2djd(mjd):
     doff = ephem.Date(0)-ephem.Date('1858/11/17')
     djd = mjd-doff
     return djd
+
 
 def raDec2AltAz(ra, dec, lat, lon, mjd, altonly=False):
     """Convert RA/Dec (and telescope site lat/lon) to alt/az.
@@ -85,7 +87,7 @@ class GalacticStacker(BaseStacker):
     """
     def __init__(self, raCol='fieldRA', decCol='fieldDec', degrees=True):
         self.colsReq = [raCol, decCol]
-        self.colsAdded = ['gall','galb']
+        self.colsAdded = ['gall', 'galb']
         self.units = ['radians', 'radians']
         self.raCol = raCol
         self.decCol = decCol
@@ -120,7 +122,7 @@ class EclipticStacker(BaseStacker):
     subtractSunLon : bool, opt
         Flag to subtract the sun's ecliptic longitude. Default False.
     """
-    def __init__(self, mjdCol='observationStartMJD', raCol='fieldRA',decCol='fieldDec', degrees=True,
+    def __init__(self, mjdCol='observationStartMJD', raCol='fieldRA', decCol='fieldDec', degrees=True,
                  subtractSunLon=False):
 
         self.colsReq = [mjdCol, raCol, decCol]

--- a/python/lsst/sims/maf/stackers/ditherStackers.py
+++ b/python/lsst/sims/maf/stackers/ditherStackers.py
@@ -268,8 +268,8 @@ class RandomDitherFieldPerNightStacker(RandomDitherFieldPerVisitStacker):
         If set, then used as the random seed for the numpy random number generation for the dither offsets.
         Default None.
     """
-    def __init__(self, raCol='fieldRA', decCol='fieldDec', degrees=True, fieldIdCol='fieldId', nightCol='night',
-                 maxDither=1.75, inHex=True, randomSeed=None):
+    def __init__(self, raCol='fieldRA', decCol='fieldDec', degrees=True, fieldIdCol='fieldId',
+                 nightCol='night', maxDither=1.75, inHex=True, randomSeed=None):
         """
         @ MaxDither in degrees
         """
@@ -449,7 +449,7 @@ class SpiralDitherFieldPerVisitStacker(BaseStacker):
         self.inHex = inHex
         # self.units used for plot labels
         if self.degrees:
-            self.units =  ['deg', 'deg']
+            self.units = ['deg', 'deg']
         else:
             self.units = ['rad', 'rad']
         # Values required for framework operation: this specifies the names of the new columns.
@@ -547,8 +547,8 @@ class SpiralDitherFieldPerNightStacker(SpiralDitherFieldPerVisitStacker):
         If False, offsets can lie anywhere out to the edges of the maxDither circle.
         Default True.
     """
-    def __init__(self, raCol='fieldRA', decCol='fieldDec', degrees=True, fieldIdCol='fieldId', nightCol='night',
-                 numPoints=60, maxDither=1.75, nCoils=5, inHex=True):
+    def __init__(self, raCol='fieldRA', decCol='fieldDec', degrees=True, fieldIdCol='fieldId',
+                 nightCol='night', numPoints=60, maxDither=1.75, nCoils=5, inHex=True):
         """
         @ MaxDither in degrees
         """
@@ -629,8 +629,8 @@ class SpiralDitherPerNightStacker(SpiralDitherFieldPerVisitStacker):
         If False, offsets can lie anywhere out to the edges of the maxDither circle.
         Default True.
     """
-    def __init__(self, raCol='fieldRA', decCol='fieldDec', degrees=True, fieldIdCol='fieldId', nightCol='night',
-                 numPoints=60, maxDither=1.75, nCoils=5, inHex=True):
+    def __init__(self, raCol='fieldRA', decCol='fieldDec', degrees=True, fieldIdCol='fieldId',
+                 nightCol='night', numPoints=60, maxDither=1.75, nCoils=5, inHex=True):
         """
         @ MaxDither in degrees
         """

--- a/python/lsst/sims/maf/stackers/ditherStackers.py
+++ b/python/lsst/sims/maf/stackers/ditherStackers.py
@@ -967,13 +967,17 @@ class RandomRotDitherPerFilterChangeStacker(BaseStacker):
         Abs(maximum) rotational dither, in degrees. The dithers then will be
         between -maxDither to maxDither.
         Default: 90 degrees.
+    maxRotAngle : float, optional
+        Maximum rotator angle possible for the camera. Default 90 degrees.
+    minRotAngle : float, optional
+        Minimum rotator angle possible for the camera. Default -90 degrees.
     randomSeed: int, optional
         If set, then used as the random seed for the numpy random number
         generation for the dither offsets.
         Default: None.
     """
     def __init__(self, rotTelCol= 'rotTelPos', filterCol= 'filter', degrees=True,
-                 maxDither= 90., randomSeed=None):
+                 maxDither= 90., maxRotAngle=90, minRotAngle=-90, randomSeed=None):
         """
         @ MaxDither in degrees.
         """
@@ -982,6 +986,8 @@ class RandomRotDitherPerFilterChangeStacker(BaseStacker):
         self.filterCol = filterCol
         self.degrees = degrees
         self.maxDither = maxDither
+        self.maxRotAngle = maxRotAngle
+        self.minRotAngle = minRotAngle
         self.randomSeed = randomSeed
         # self.units used for plot labels
         if self.degrees:
@@ -1024,8 +1030,8 @@ class RandomRotDitherPerFilterChangeStacker(BaseStacker):
 
         # BUT the camera rotator cannot go further than +/- 90 degrees.
         # Without a better alternative, let's just cut off any values which exceed this range.
-        maxRotTelPos = 90.0
-        minRotTelPos = -90.0
+        maxRotTelPos = self.maxRotAngle
+        minRotTelPos = self.minRotAngle
         if not self.degrees:
             maxRotTelPos = np.radians(maxRotTelPos)
             minRotTelPos = np.radians(minRotTelPos)

--- a/python/lsst/sims/maf/stackers/generalStackers.py
+++ b/python/lsst/sims/maf/stackers/generalStackers.py
@@ -3,7 +3,6 @@ import numpy as np
 import palpy
 from lsst.sims.utils import Site, m5_flat_sed
 from .baseStacker import BaseStacker
-from builtins import str
 
 __all__ = ['NormAirmassStacker', 'ParallaxFactorStacker', 'HourAngleStacker',
            'FilterColorStacker', 'ZenithDistStacker', 'ParallacticAngleStacker',
@@ -41,10 +40,10 @@ class FiveSigmaStacker(BaseStacker):
         for filtername in filts:
             infilt = np.where(simData[self.filterCol] == filtername)
             simData['m5_simsUtils'][infilt] = m5_flat_sed(filtername,
-                                                            simData[infilt][self.skybrightnessCol],
-                                                            simData[infilt][self.seeingCol],
-                                                            simData[infilt][self.exptimeCol],
-                                                            simData[infilt][self.airmassCol])
+                                                          simData[infilt][self.skybrightnessCol],
+                                                          simData[infilt][self.seeingCol],
+                                                          simData[infilt][self.exptimeCol],
+                                                          simData[infilt][self.airmassCol])
         return simData
 
 

--- a/python/lsst/sims/maf/stackers/getColInfo.py
+++ b/python/lsst/sims/maf/stackers/getColInfo.py
@@ -4,6 +4,7 @@ from .baseStacker import BaseStacker
 
 __all__ = ['ColInfo']
 
+
 class ColInfo(object):
     """Class to hold the unit and source locations for columns.
 
@@ -16,8 +17,8 @@ class ColInfo(object):
         self.defaultUnit = ''
         self.unitDict = {'fieldId': '#',
                          'filter': 'filter',
-                         'seqnNum' : '#',
-                         'expMJD' : 'MJD',
+                         'seqnNum': '#',
+                         'expMJD': 'MJD',
                          'observationStartMJD': 'MJD',
                          'observationStartLST': 'deg',
                          'visitExposureTime': 's',
@@ -27,8 +28,8 @@ class ColInfo(object):
                          'rotTelPos': 'deg',
                          'rawSeeing': 'arcsec',
                          'finSeeing': 'arcsec',
-                         'FWHMeff' : 'arcsec',
-                         'FWHMgeom' : 'arcsec',
+                         'FWHMeff': 'arcsec',
+                         'FWHMgeom': 'arcsec',
                          'seeingFwhmEff': 'arcsec',
                          'seeingFwhmGeom': 'arcsec',
                          'seeingFwhm500': 'arcsec',
@@ -41,7 +42,7 @@ class ColInfo(object):
                          'dist2Moon': 'rad',
                          'filtSkyBrightness': 'mag/sq arcsec',
                          'skyBrightness': 'mag/sq arcsec',
-                         'fiveSigmaDepth':'mag',
+                         'fiveSigmaDepth': 'mag',
                          'solarElong': 'degrees'}
         # Go through the available stackers and add any units, and identify their
         #   source methods.

--- a/python/lsst/sims/maf/stackers/m5OptimalStacker.py
+++ b/python/lsst/sims/maf/stackers/m5OptimalStacker.py
@@ -17,9 +17,9 @@ def generate_sky_slopes():
     mjd = 57000
     nside = 32
     airmass_limit = 2.0
-    dec, ra = hp.pix2ang(nside,np.arange(hp.nside2npix(nside)))
+    dec, ra = hp.pix2ang(nside, np.arange(hp.nside2npix(nside)))
     dec = np.pi/2 - dec
-    sm.setRaDecMjd(ra,dec,mjd)
+    sm.setRaDecMjd(ra, dec, mjd)
     mags = sm.returnMags()
     filters = mags.dtype.names
     filter_slopes = {}
@@ -28,6 +28,7 @@ def generate_sky_slopes():
         pf = np.polyfit(sm.airmass[good], mags[filterName][good], 1)
         filter_slopes[filterName] = pf[0]
     print(filter_slopes)
+
 
 class M5OptimalStacker(BaseStacker):
     """
@@ -100,13 +101,12 @@ class M5OptimalStacker(BaseStacker):
         for filterName in np.unique(simData[self.filterCol]):
             deltaSky = skySlopes[filterName]*(simData[self.airmassCol] - min_airmass_possible)
             deltaSky[np.where((simData[self.moonAltCol] > 0) |
-                              (simData[self.sunAltCol] >  np.radians(-18.)))] = 0
+                              (simData[self.sunAltCol] > np.radians(-18.)))] = 0
             # Using Approximation that FWHM~X^0.6. So seeing term in m5 of: 0.25 * log (7.0/FWHMeff )
             # Goes to 0.15 log(FWHM_min / FWHM_eff) in the difference
-            m5Optimal = simData[self.m5Col] - \
-                        0.5*deltaSky - \
-                        0.15*np.log10(min_airmass_possible / simData[self.airmassCol]) - \
-                        kAtm[filterName]*(min_airmass_possible - simData[self.airmassCol])
+            m5Optimal = (simData[self.m5Col] - 0.5*deltaSky -
+                         0.15*np.log10(min_airmass_possible / simData[self.airmassCol]) -
+                         kAtm[filterName]*(min_airmass_possible - simData[self.airmassCol]))
             good = np.where(simData[self.filterCol] == filterName)
             simData['m5Optimal'][good] = m5Optimal[good]
         return simData

--- a/python/lsst/sims/maf/stackers/moStackers.py
+++ b/python/lsst/sims/maf/stackers/moStackers.py
@@ -4,6 +4,7 @@ import warnings
 
 __all__ = ['BaseMoStacker', 'MoMagStacker', 'EclStacker']
 
+
 class BaseMoStacker(BaseStacker):
     """Base class for moving object stackers.
 

--- a/python/lsst/sims/maf/stackers/nFollowStacker.py
+++ b/python/lsst/sims/maf/stackers/nFollowStacker.py
@@ -15,49 +15,49 @@ def findTelescopes(minSize=3.):
     np.recarray
         Array of large telescopes with columns [aperture, name, lat, lon].
     """
-    ## Aperture  Name Location http://astro.nineplanets.org/bigeyes.html
-    telescopes =[
-        [10.4, 'Gran Canarias','La Palma'],
-        [10.0, 'Keck','Mauna Kea'],
+    # Aperture  Name Location http://astro.nineplanets.org/bigeyes.html
+    telescopes = [
+        [10.4, 'Gran Canarias', 'La Palma'],
+        [10.0, 'Keck', 'Mauna Kea'],
         [10.0, 'Keck II', 'Mauna Kea'],
         [9.2, 'SALT', 'South African Astronomical Observatory'],
-        [9.2,'Hobby-Eberly', 'Mt. Fowlkes'],
-        [8.4,'Large Binocular Telescope','Mt. Graham'],
-        [8.3,'Subaru','Mauna Kea'],
-        [8.2,'Antu','Cerro Paranal'],
-        [8.2,'Kueyen','Cerro Paranal'],
-        [8.2,'Melipal','Cerro Paranal'],
-        [8.2,'Yepun','Cerro Paranal'],
-        [8.1,'Gemini North','Mauna Kea'],
-        [8.1,'Gemini South','Cerro Pachon'],
-        [6.5,'MMT','Mt. Hopkins'],
-        [6.5,'Walter Baade','La Serena'],
-        [6.5,'Landon Clay','La Serena'],
-        [6.0,'Bolshoi Teleskop Azimutalnyi','Nizhny Arkhyz'],
-        [6.0,'LZT','British Columbia'],
-        [5.0,'Hale','Palomar Mountain'],
-        [4.3,'Dicovery Channel','Lowell Observatory'],
-        [4.2,'William Herschel','La Palma'],
-        [4.2,'SOAR','Cerro Pachon'],
-        [4.2,'LAMOST','Xinglong Station'],
-        [4.0,'Victor Blanco','Cerro Tololo'],
-        [4.0,'Vista','Cerro Paranal'],
-        [3.9,'Anglo-Australian','Coonabarabran'],
-        [3.8,'Mayall','Kitt Peak'],
-        [3.8,'UKIRT','Mauna Kea'],
-        [3.6,'360','Cerro La Silla'],
-        [3.6,'Canada-France-Hawaii','Mauna Kea'],
-        [3.6,'Telescopio Nazionale Galileo','La Palma'],
-        [3.5,'MPI-CAHA','Calar Alto'],
-        [3.5,'New Technology','Cerro La Silla'],
-        [3.5,'ARC','Apache Point'],
-        [3.5,'WIYN','Kitt Peak'],
-        [3.0,'Shane','Mount Hamilton'],
-        [3.0,'NASA IRTF','Mauna Kea'],
+        [9.2, 'Hobby-Eberly', 'Mt. Fowlkes'],
+        [8.4, 'Large Binocular Telescope', 'Mt. Graham'],
+        [8.3, 'Subaru', 'Mauna Kea'],
+        [8.2, 'Antu', 'Cerro Paranal'],
+        [8.2, 'Kueyen', 'Cerro Paranal'],
+        [8.2, 'Melipal', 'Cerro Paranal'],
+        [8.2, 'Yepun', 'Cerro Paranal'],
+        [8.1, 'Gemini North', 'Mauna Kea'],
+        [8.1, 'Gemini South', 'Cerro Pachon'],
+        [6.5, 'MMT', 'Mt. Hopkins'],
+        [6.5, 'Walter Baade', 'La Serena'],
+        [6.5, 'Landon Clay', 'La Serena'],
+        [6.0, 'Bolshoi Teleskop Azimutalnyi', 'Nizhny Arkhyz'],
+        [6.0, 'LZT', 'British Columbia'],
+        [5.0, 'Hale', 'Palomar Mountain'],
+        [4.3, 'Dicovery Channel', 'Lowell Observatory'],
+        [4.2, 'William Herschel', 'La Palma'],
+        [4.2, 'SOAR', 'Cerro Pachon'],
+        [4.2, 'LAMOST', 'Xinglong Station'],
+        [4.0, 'Victor Blanco', 'Cerro Tololo'],
+        [4.0, 'Vista', 'Cerro Paranal'],
+        [3.9, 'Anglo-Australian', 'Coonabarabran'],
+        [3.8, 'Mayall', 'Kitt Peak'],
+        [3.8, 'UKIRT', 'Mauna Kea'],
+        [3.6, '360', 'Cerro La Silla'],
+        [3.6, 'Canada-France-Hawaii', 'Mauna Kea'],
+        [3.6, 'Telescopio Nazionale Galileo', 'La Palma'],
+        [3.5, 'MPI-CAHA', 'Calar Alto'],
+        [3.5, 'New Technology', 'Cerro La Silla'],
+        [3.5, 'ARC', 'Apache Point'],
+        [3.5, 'WIYN', 'Kitt Peak'],
+        [3.0, 'Shane', 'Mount Hamilton'],
+        [3.0, 'NASA IRTF', 'Mauna Kea'],
     ]
 
     scopes = np.zeros(len(telescopes), dtype = list(zip(
-        ['aperture','name','lat','lon'],[float, (np.str, 38), float, float])))
+        ['aperture', 'name', 'lat', 'lon'], [float, (np.str, 38), float, float])))
 
     # name, lat (S negative), lon (W negative)
     observatories = [
@@ -67,33 +67,33 @@ def findTelescopes(minSize=3.):
         ['Lowell Observatory', 35, 12, -111, 40],
         ['Apache Point', 32, 47, -105, 49],
         ['Mount Hamilton', 37, 21, -121, 38],
-        ['South African Astronomical Observatory', -32, 23, 20 ,49],
-        ['Cerro Pachon',  -30, 20, -70, 59],
-        ['Coonabarabran',-31, 17, 149, 0o4],
-        ['Mt. Fowlkes', 30,40,-104,1],
+        ['South African Astronomical Observatory', -32, 23, 20, 49],
+        ['Cerro Pachon', -30, 20, -70, 59],
+        ['Coonabarabran', -31, 17, 149, 0o4],
+        ['Mt. Fowlkes', 30, 40, -104, 1],
         ['La Palma', 28, 46, -17, 53],
-        ['Mt. Graham',32, 42, -109, 53],
-        ['Calar Alto', 37,13,-2,33],
-        ['British Columbia',49,17, -122,34],
-        ['Kitt Peak',31,57,-111,37],
-        ['La Serena',-30,10,-70,48],
-        ['Palomar Mountain',33,21,-116,52],
-        ['Xinglong Station',40,23,105,50],
-        ['Mt. Hopkins', 31,41, -110,53],
-        ['Cerro Tololo',-30,10,-70,49],
-        ['Mauna Kea', 19,50,-155,28]
+        ['Mt. Graham', 32, 42, -109, 53],
+        ['Calar Alto', 37, 13, -2, 33],
+        ['British Columbia', 49, 17, -122, 34],
+        ['Kitt Peak', 31, 57, -111, 37],
+        ['La Serena', -30, 10, -70, 48],
+        ['Palomar Mountain', 33, 21, -116, 52],
+        ['Xinglong Station', 40, 23, 105, 50],
+        ['Mt. Hopkins', 31, 41, -110, 53],
+        ['Cerro Tololo', -30, 10, -70, 49],
+        ['Mauna Kea', 19, 50, -155, 28]
     ]
 
     # Make a nice little dict to look up the observatory positions
     obs = {}
-    for i,ob in enumerate(observatories):
+    for i, ob in enumerate(observatories):
         obs[ob[0]] = [(np.abs(ob[1])+ob[2]/60.)*(ob[1]/np.abs(ob[1])),
                       (np.abs(ob[3])+ob[4]/60.)*(ob[3]/np.abs(ob[3]))]
 
-    for i,telescope in enumerate(telescopes):
+    for i, telescope in enumerate(telescopes):
         scopes['aperture'][i] = telescope[0]
         scopes['name'][i] = telescope[1]
-        scopes['lat'][i],scopes['lon'][i] = obs[telescope[2]]
+        scopes['lat'][i], scopes['lon'][i] = obs[telescope[2]]
 
     scopes = scopes[np.where(scopes['aperture'] >= minSize)]
     return scopes

--- a/tests/testStackers.py
+++ b/tests/testStackers.py
@@ -7,7 +7,8 @@ import warnings
 import unittest
 import lsst.utils.tests
 import lsst.sims.maf.stackers as stackers
-from lsst.sims.utils import _galacticFromEquatorial, calcLmstLast, Site, _altAzPaFromRaDec, ObservationMetaData
+from lsst.sims.utils import _galacticFromEquatorial, calcLmstLast, Site, _altAzPaFromRaDec, \
+    ObservationMetaData
 
 matplotlib.use("Agg")
 
@@ -217,6 +218,27 @@ class TestStackerClasses(unittest.TestCase):
         # Check that dithers on the same night are the same.
         self._tDitherPerNight(diffsra, diffsdec, data['fieldRA'],
                               data['fieldDec'], data['night'])
+
+    def testRandomRotDitherPerFilterChangeStacker(self):
+        """
+        Test the rotational dither stacker.
+        """
+        maxDither = 90
+        filt = np.array(['r', 'r', 'r', 'g', 'g', 'g', 'r', 'r'])
+        rotTelPos = np.array([0, 0, 1, 0, .5, 1, 0, 180], float)
+        data = np.zeros(len(filt), dtype=list(zip(['filter', 'rotTelPos'], [(np.str_, 1), float])))
+        data['filter'] = filt
+        data['rotTelPos'] = rotTelPos
+        stacker = stackers.RandomRotDitherPerFilterChangeStacker(maxDither=maxDither, degrees=True)
+        data = stacker.run(data)
+        randomDithers = data['randomDitherPerFilterChangeRotTelPos']
+        rotOffsets = rotTelPos - randomDithers
+        self.assertEqual(rotOffsets[0], 0)
+        offsetChanges = np.where(rotOffsets[1:] != rotOffsets[:-1])[0]
+        filtChanges = np.where(filt[1:] != filt[:-1])[0]
+        # Don't count last offset change because this was just value to force min/max limit.
+        self.assertTrue(np.all(offsetChanges[:-1] == filtChanges))
+        self.assertTrue(np.all(randomDithers <= 90.0))
 
     def testHAStacker(self):
         """Test the Hour Angle stacker"""

--- a/tests/testStackers.py
+++ b/tests/testStackers.py
@@ -226,11 +226,11 @@ class TestStackerClasses(unittest.TestCase):
         maxDither = 90
         filt = np.array(['r', 'r', 'r', 'g', 'g', 'g', 'r', 'r'])
         rotTelPos = np.array([0, 0, 1, 0, .5, 1, 0, 180], float)
-        data = np.zeros(len(filt), dtype=list(zip(['filter', 'rotTelPos'], [(np.str_, 1), float])))
-        data['filter'] = filt
-        data['rotTelPos'] = rotTelPos
+        odata = np.zeros(len(filt), dtype=list(zip(['filter', 'rotTelPos'], [(np.str_, 1), float])))
+        odata['filter'] = filt
+        odata['rotTelPos'] = rotTelPos
         stacker = stackers.RandomRotDitherPerFilterChangeStacker(maxDither=maxDither, degrees=True)
-        data = stacker.run(data)
+        data = stacker.run(odata)
         randomDithers = data['randomDitherPerFilterChangeRotTelPos']
         rotOffsets = rotTelPos - randomDithers
         self.assertEqual(rotOffsets[0], 0)
@@ -239,6 +239,11 @@ class TestStackerClasses(unittest.TestCase):
         # Don't count last offset change because this was just value to force min/max limit.
         self.assertTrue(np.all(offsetChanges[:-1] == filtChanges))
         self.assertTrue(np.all(randomDithers <= 90.0))
+        stacker = stackers.RandomRotDitherPerFilterChangeStacker(maxDither=maxDither,
+                                                                 degrees=True, maxRotAngle = 30)
+        data = stacker.run(odata)
+        randomDithers = data['randomDitherPerFilterChangeRotTelPos']
+        self.assertTrue(randomDithers.max(), 30.0)
 
     def testHAStacker(self):
         """Test the Hour Angle stacker"""


### PR DESCRIPTION
Add a rotTelPos dither stacker. 
This stacker adds a random offset to all rotTelPos values after a filter change. 
The stacker was contributed by humnaawan (who I can't tag here apparently). 

There is a problem when the rotTelPos exceeds the limits, due to the random offset. I haven't tried to solve this properly, but simply cut the resulting rotTelPos back to the limit in this case. 