### PR TITLE
OpSimFieldStacker.

### DIFF
--- a/python/lsst/sims/maf/slicers/baseSpatialSlicer.py
+++ b/python/lsst/sims/maf/slicers/baseSpatialSlicer.py
@@ -15,7 +15,7 @@ from lsst.sims.maf.plots.spatialPlotters import BaseHistogram, BaseSkyMap
 # For the footprint generation and conversion between galactic/equatorial coordinates.
 from lsst.obs.lsstSim import LsstSimMapper
 from lsst.sims.coordUtils import _chipNameFromRaDec
-from lsst.sims.utils import ObservationMetaData, _treexyz, _rad_length, _buildTree
+from lsst.sims.utils import ObservationMetaData, _xyz_from_ra_dec, xyz_angular_radius, _buildTree
 
 from .baseSlicer import BaseSlicer
 
@@ -130,8 +130,8 @@ class BaseSpatialSlicer(BaseSlicer):
                 indices = self.sliceLookup[islice]
                 slicePoint['chipNames'] = self.chipNames[islice]
             else:
-                sx, sy, sz = _treexyz(self.slicePoints['ra'][islice],
-                                      self.slicePoints['dec'][islice])
+                sx, sy, sz = _xyz_from_ra_dec(self.slicePoints['ra'][islice],
+                                              self.slicePoints['dec'][islice])
                 # Query against tree.
                 indices = self.opsimtree.query_ball_point((sx, sy, sz), self.rad)
 
@@ -175,7 +175,7 @@ class BaseSpatialSlicer(BaseSlicer):
             lon = simData[self.lonCol]
         for ind, ra, dec, rotSkyPos, mjd in zip(np.arange(simData.size), lon, lat,
                                                 simData[self.rotSkyPosColName], simData[self.mjdColName]):
-            dx, dy, dz = _treexyz(ra, dec)
+            dx, dy, dz = _xyz_from_ra_dec(ra, dec)
             # Find healpixels inside the FoV
             hpIndices = np.array(self.opsimtree.query_ball_point((dx, dy, dz), self.rad))
             if hpIndices.size > 0:
@@ -215,4 +215,4 @@ class BaseSpatialSlicer(BaseSlicer):
 
     def _setRad(self, radius=1.75):
         """Set radius (in degrees) for kdtree search using utility function from mafUtils."""
-        self.rad = _rad_length(radius)
+        self.rad = xyz_angular_radius(radius)

--- a/python/lsst/sims/maf/slicers/baseSpatialSlicer.py
+++ b/python/lsst/sims/maf/slicers/baseSpatialSlicer.py
@@ -11,12 +11,11 @@ import numpy as np
 from functools import wraps
 from scipy.spatial import cKDTree as kdtree
 from lsst.sims.maf.plots.spatialPlotters import BaseHistogram, BaseSkyMap
-from lsst.sims.maf.utils import _treexyz, _rad_length, _buildTree
 
 # For the footprint generation and conversion between galactic/equatorial coordinates.
 from lsst.obs.lsstSim import LsstSimMapper
 from lsst.sims.coordUtils import _chipNameFromRaDec
-from lsst.sims.utils import ObservationMetaData
+from lsst.sims.utils import ObservationMetaData, _treexyz, _rad_length, _buildTree
 
 from .baseSlicer import BaseSlicer
 
@@ -210,9 +209,9 @@ class BaseSpatialSlicer(BaseSlicer):
 
         simDataRA, simDataDec = RA and Dec values (in radians).
         leafsize = the number of Ra/Dec pointings in each leaf node."""
-        self.opsimtree = _buildTree(simDataRa=simDataRa,
-                                    simDataDec=simDataDec,
-                                    leafsize=leafsize)
+        self.opsimtree = _buildTree(simDataRa,
+                                    simDataDec,
+                                    leafsize)
 
     def _setRad(self, radius=1.75):
         """Set radius (in degrees) for kdtree search using utility function from mafUtils."""

--- a/python/lsst/sims/maf/slicers/baseSpatialSlicer.py
+++ b/python/lsst/sims/maf/slicers/baseSpatialSlicer.py
@@ -15,7 +15,7 @@ from lsst.sims.maf.plots.spatialPlotters import BaseHistogram, BaseSkyMap
 # For the footprint generation and conversion between galactic/equatorial coordinates.
 from lsst.obs.lsstSim import LsstSimMapper
 from lsst.sims.coordUtils import _chipNameFromRaDec
-from lsst.sims.utils import ObservationMetaData, _xyz_from_ra_dec, xyz_angular_radius, _buildTree
+import lsst.sims.utils as simsUtils
 
 from .baseSlicer import BaseSlicer
 
@@ -130,8 +130,8 @@ class BaseSpatialSlicer(BaseSlicer):
                 indices = self.sliceLookup[islice]
                 slicePoint['chipNames'] = self.chipNames[islice]
             else:
-                sx, sy, sz = _xyz_from_ra_dec(self.slicePoints['ra'][islice],
-                                              self.slicePoints['dec'][islice])
+                sx, sy, sz = simsUtils._xyz_from_ra_dec(self.slicePoints['ra'][islice],
+                                                        self.slicePoints['dec'][islice])
                 # Query against tree.
                 indices = self.opsimtree.query_ball_point((sx, sy, sz), self.rad)
 
@@ -175,14 +175,14 @@ class BaseSpatialSlicer(BaseSlicer):
             lon = simData[self.lonCol]
         for ind, ra, dec, rotSkyPos, mjd in zip(np.arange(simData.size), lon, lat,
                                                 simData[self.rotSkyPosColName], simData[self.mjdColName]):
-            dx, dy, dz = _xyz_from_ra_dec(ra, dec)
+            dx, dy, dz = simsUtils._xyz_from_ra_dec(ra, dec)
             # Find healpixels inside the FoV
             hpIndices = np.array(self.opsimtree.query_ball_point((dx, dy, dz), self.rad))
             if hpIndices.size > 0:
-                obs_metadata = ObservationMetaData(pointingRA=np.degrees(ra),
-                                                   pointingDec=np.degrees(dec),
-                                                   rotSkyPos=np.degrees(rotSkyPos),
-                                                   mjd=mjd)
+                obs_metadata = simsUtils.ObservationMetaData(pointingRA=np.degrees(ra),
+                                                             pointingDec=np.degrees(dec),
+                                                             rotSkyPos=np.degrees(rotSkyPos),
+                                                             mjd=mjd)
 
                 chipNames = _chipNameFromRaDec(self.slicePoints['ra'][hpIndices],
                                                self.slicePoints['dec'][hpIndices],
@@ -209,10 +209,10 @@ class BaseSpatialSlicer(BaseSlicer):
 
         simDataRA, simDataDec = RA and Dec values (in radians).
         leafsize = the number of Ra/Dec pointings in each leaf node."""
-        self.opsimtree = _buildTree(simDataRa,
-                                    simDataDec,
-                                    leafsize)
+        self.opsimtree = simsUtils._buildTree(simDataRa,
+                                              simDataDec,
+                                              leafsize)
 
     def _setRad(self, radius=1.75):
         """Set radius (in degrees) for kdtree search using utility function from mafUtils."""
-        self.rad = xyz_angular_radius(radius)
+        self.rad = simsUtils.xyz_angular_radius(radius)

--- a/python/lsst/sims/maf/stackers/generalStackers.py
+++ b/python/lsst/sims/maf/stackers/generalStackers.py
@@ -2,8 +2,8 @@ import warnings
 import numpy as np
 from scipy.spatial import cKDTree as kdtree
 import palpy
-from lsst.sims.utils import Site, m5_flat_sed
-from lsst.sims.maf.utils import getOpSimField, _treexyz, _rad_length, _buildTree
+from lsst.sims.utils import Site, m5_flat_sed, _treexyz, _rad_length, _buildTree
+from lsst.sims.survey.fields import FieldsDatabase
 from .baseStacker import BaseStacker
 
 __all__ = ['NormAirmassStacker', 'ParallaxFactorStacker', 'HourAngleStacker',
@@ -418,10 +418,11 @@ class OpSimFieldStacker(BaseStacker):
         self.raCol = raCol
         self.decCol = decCol
         self.degrees = degrees
-        fields = getOpSimField()  # Returned RA/Dec coordinates in radians
-        asort = np.argsort(fields['field_id'])
-        self.tree = _buildTree(simDataRa=fields['RA'][asort],
-                               simDataDec=fields['dec'][asort])
+        fields_db = FieldsDatabase()
+        fields = fields_db.get_id_ra_dec_arrays("select * from Field")  # Returned RA/Dec coordinates in degrees
+        asort = np.argsort(fields['fieldId'])
+        self.tree = _buildTree(np.radians(fields['ra'][asort]),
+                               np.radians(fields['dec'][asort]))
 
     def _run(self, simData, cols_present=False):
         if cols_present:

--- a/python/lsst/sims/maf/stackers/generalStackers.py
+++ b/python/lsst/sims/maf/stackers/generalStackers.py
@@ -419,7 +419,7 @@ class OpSimFieldStacker(BaseStacker):
         self.decCol = decCol
         self.degrees = degrees
         fields_db = FieldsDatabase()
-        fieldid, ra, dec = fields_db.get_id_ra_dec_arrays("select * from Field")  # Returned RA/Dec coordinates in degrees
+        fieldid, ra, dec = fields_db.get_id_ra_dec_arrays("select * from Field;")  # Returned RA/Dec coordinates in degrees
         asort = np.argsort(fieldid)
         self.tree = _buildTree(np.radians(ra[asort]),
                                np.radians(dec[asort]))

--- a/python/lsst/sims/maf/stackers/generalStackers.py
+++ b/python/lsst/sims/maf/stackers/generalStackers.py
@@ -419,10 +419,10 @@ class OpSimFieldStacker(BaseStacker):
         self.decCol = decCol
         self.degrees = degrees
         fields_db = FieldsDatabase()
-        fields = fields_db.get_id_ra_dec_arrays("select * from Field")  # Returned RA/Dec coordinates in degrees
-        asort = np.argsort(fields['fieldId'])
-        self.tree = _buildTree(np.radians(fields['ra'][asort]),
-                               np.radians(fields['dec'][asort]))
+        fieldid, ra, dec = fields_db.get_id_ra_dec_arrays("select * from Field")  # Returned RA/Dec coordinates in degrees
+        asort = np.argsort(fieldid)
+        self.tree = _buildTree(np.radians(ra[asort]),
+                               np.radians(dec[asort]))
 
     def _run(self, simData, cols_present=False):
         if cols_present:

--- a/python/lsst/sims/maf/utils/mafUtils.py
+++ b/python/lsst/sims/maf/utils/mafUtils.py
@@ -1,14 +1,11 @@
 import importlib
 import os
 import numpy as np
-from scipy.spatial import cKDTree as kdtree
-from lsst.sims.survey.fields import FieldsDatabase
 import healpy as hp
 import warnings
 
 __all__ = ['optimalBins', 'percentileClipping',
-           'gnomonic_project_toxy', 'radec2pix',
-           'getOpSimField', '_treexyz', '_rad_length', '_buildTree']
+           'gnomonic_project_toxy', 'radec2pix']
 
 
 def optimalBins(datain, binmin=None, binmax=None, nbinMax=200, nbinMin=1):
@@ -143,115 +140,3 @@ def radec2pix(nside, ra, dec):
     lat = np.pi/2. - dec
     hpid = hp.ang2pix(nside, lat, ra )
     return hpid
-
-
-def getOpSimField(sqlconstraint="select * from Field"):
-    """
-    Get list of OpSim fields.
-
-    Parameters:
-    -----------
-    sqlconstraint : string
-        Sql constraints for the field selection. Default is, get all fields.
-
-    Returns:
-    --------
-    numpy.ndarray
-        A numpy structured array with columns for fields matching the sqlconstraint.
-    """
-
-    db = FieldsDatabase()
-    res = db.get_field_set(sqlconstraint)
-    names = ['field_id', 'fov_rad', 'RA', 'dec', 'gl', 'gb', 'el', 'eb']
-    types = [int, float, float, float, float, float, float, float]
-    fields = np.zeros(len(res), dtype=list(zip(names, types)))
-
-    for i, row in enumerate(res):
-        fields['field_id'][i] = row[0]
-        fields['fov_rad'][i] = np.radians(row[1])
-        fields['RA'][i] = np.radians(row[2])
-        fields['dec'][i] = np.radians(row[3])
-        fields['gl'][i] = row[4]
-        fields['gb'][i] = row[5]
-        fields['el'][i] = row[6]
-        fields['eb'][i] = row[7]
-
-    return fields
-
-
-def opsimfields_kd_tree(leafsize=100):
-    """
-    Generate a KD-tree of OpSim fields locations
-
-    Parameters
-    ----------
-    leafsize : int (100)
-        Leafsize of the kdtree
-
-    Returns
-    -------
-    tree : scipy kdtree
-    """
-
-    fields = getOpSimField()
-    x, y, z = _treexyz(fields['RA'], fields['dec'])
-    tree = kdtree(list(zip(x, y, z)), leafsize=leafsize, balanced_tree=False, compact_nodes=False)
-    return tree
-
-
-def _treexyz(ra, dec):
-    """
-    Utility to convert RA,dec postions in x,y,z space, useful for constructing KD-trees.
-
-    Parameters
-    ----------
-    ra : float or array
-        RA in radians
-    dec : float or array
-        Dec in radians
-
-    Returns
-    -------
-    x,y,z : floats or arrays
-        The position of the given points on the unit sphere.
-    """
-    # Note ra/dec can be arrays.
-    x = np.cos(dec) * np.cos(ra)
-    y = np.cos(dec) * np.sin(ra)
-    z = np.sin(dec)
-    return x, y, z
-
-
-def _rad_length(radius=1.75):
-    """
-    Convert an angular radius into a physical radius for a kdtree search.
-
-    Parameters
-    ----------
-    radius : float
-        Radius in degrees.
-    """
-    x0, y0, z0 = (1, 0, 0)
-    x1, y1, z1 = _treexyz(np.radians(radius), 0)
-    result = np.sqrt((x1-x0)**2+(y1-y0)**2+(z1-z0)**2)
-    return result
-
-
-def _buildTree(simDataRa, simDataDec, leafsize=100):
-    """Build KD tree on simDataRA/Dec and set radius (via setRad) for matching.
-
-    simDataRA, simDataDec = RA and Dec values (in radians).
-    leafsize = the number of Ra/Dec pointings in each leaf node."""
-    if np.any(np.abs(simDataRa) > np.pi * 2.0) or np.any(np.abs(simDataDec) > np.pi * 2.0):
-        raise ValueError('Expecting RA and Dec values to be in radians.')
-    x, y, z = _treexyz(simDataRa, simDataDec)
-    data = list(zip(x, y, z))
-    if np.size(data) > 0:
-        try:
-            opsimtree = kdtree(data, leafsize=leafsize, balanced_tree=False, compact_nodes=False)
-        except TypeError:
-            opsimtree = kdtree(data, leafsize=leafsize)
-    else:
-        raise ValueError('SimDataRA and Dec should have length greater than 0.')
-
-    return opsimtree

--- a/tests/testStackers.py
+++ b/tests/testStackers.py
@@ -7,9 +7,9 @@ import warnings
 import unittest
 import lsst.utils.tests
 import lsst.sims.maf.stackers as stackers
-from lsst.sims.maf.utils import getOpSimField
 from lsst.sims.utils import _galacticFromEquatorial, calcLmstLast, Site, _altAzPaFromRaDec, \
     ObservationMetaData
+from lsst.sims.survey.fields import FieldsDatabase
 
 matplotlib.use("Agg")
 
@@ -353,14 +353,17 @@ class TestStackerClasses(unittest.TestCase):
         s = stackers.OpSimFieldStacker(raCol='ra', decCol='dec', degrees=False)
 
         # First sanity check. Make sure the center of the fields returns the right field id
-        opsim_fields = getOpSimField()
+        opsim_fields_db = FieldsDatabase()
 
-        data = np.array(list(zip(opsim_fields['RA'],
-                                 opsim_fields['dec'])),
+        # Returned RA/Dec coordinates in degrees
+        opsim_fields = opsim_fields_db.get_id_ra_dec_arrays("select * from Field")
+
+        data = np.array(list(zip(np.radians(opsim_fields['ra']),
+                                 np.radians(opsim_fields['dec']))),
                         dtype=list(zip(['ra', 'dec'], [float, float])))
         new_data = s.run(data)
 
-        np.testing.assert_array_equal(opsim_fields['field_id'], new_data['fieldId'])
+        np.testing.assert_array_equal(opsim_fields['fieldId'], new_data['fieldId'])
 
         # Cherry picked a set of coordinates that should belong to a certain list of fields. These coordinates
         # are not exactly at the center of fields, but close enough that they should be classified as belonging to

--- a/tests/testStackers.py
+++ b/tests/testStackers.py
@@ -360,7 +360,7 @@ class TestStackerClasses(unittest.TestCase):
                         dtype=list(zip(['ra', 'dec'], [float, float])))
         new_data = s.run(data)
 
-        np.testing.assert_array_equal(opsim_fields['field_id'], new_data['fieldID'])
+        np.testing.assert_array_equal(opsim_fields['field_id'], new_data['fieldId'])
 
         # Cherry picked a set of coordinates that should belong to a certain list of fields. These coordinates
         # are not exactly at the center of fields, but close enough that they should be classified as belonging to
@@ -381,7 +381,7 @@ class TestStackerClasses(unittest.TestCase):
 
         new_data = s.run(data)
 
-        np.testing.assert_array_equal(field_id, new_data['fieldID'])
+        np.testing.assert_array_equal(field_id, new_data['fieldId'])
 
         # Now let's generate a set of random coordinates and make sure they are all assigned a fieldID.
         data = np.array(list(zip(np.random.rand(600) * 2. * np.pi,
@@ -390,7 +390,7 @@ class TestStackerClasses(unittest.TestCase):
 
         new_data = s.run(data)
 
-        self.assertTrue(np.all(new_data['fieldID'] > 0))
+        self.assertTrue(np.all(new_data['fieldId'] > 0))
 
 
 class TestMemory(lsst.utils.tests.MemoryTestCase):

--- a/tests/testStackers.py
+++ b/tests/testStackers.py
@@ -356,14 +356,14 @@ class TestStackerClasses(unittest.TestCase):
         opsim_fields_db = FieldsDatabase()
 
         # Returned RA/Dec coordinates in degrees
-        opsim_fields = opsim_fields_db.get_id_ra_dec_arrays("select * from Field")
+        field_id, ra, dec = opsim_fields_db.get_id_ra_dec_arrays("select * from Field;")
 
-        data = np.array(list(zip(np.radians(opsim_fields['ra']),
-                                 np.radians(opsim_fields['dec']))),
+        data = np.array(list(zip(np.radians(ra),
+                                 np.radians(dec))),
                         dtype=list(zip(['ra', 'dec'], [float, float])))
         new_data = s.run(data)
 
-        np.testing.assert_array_equal(opsim_fields['fieldId'], new_data['fieldId'])
+        np.testing.assert_array_equal(field_id, new_data['fieldId'])
 
         # Cherry picked a set of coordinates that should belong to a certain list of fields. These coordinates
         # are not exactly at the center of fields, but close enough that they should be classified as belonging to

--- a/ups/sims_maf.table
+++ b/ups/sims_maf.table
@@ -21,6 +21,8 @@ setupRequired(sims_photUtils)
 setupRequired(sims_coordUtils)
 # For the dustmaps and stellar density maps
 setupRequired(sims_maps)
+# For opsim fields
+setupRequired(sims_survey_fields)
 # For camera footprint
 setupRequired(obs_lsstSim)
 


### PR DESCRIPTION
This PR adds an OpSim Field Stacker to the list of `generalStackers`. I used the same algorithm used for healpix identification, with a spatial tree and then doing a `query_ball_point`. I am not particularly happy with getting code from the feature based scheduler to do the work here but I think the alternative, requiring the user to install the FBS to get the stacker is also not optimal. In particular, I replicated `treexyz` and `rad_length` into `mafUtils`. Maybe an alternative and more elegant approach would be to export those utility functions to `sims_utils`. The Stacker also requires `sims_survey_fields`, which contains the OpSim fields database and this was added to the ups table. 

The code also contains unit tests to check basic functionality of the Stacker. It makes three tests;

1. Make sure the RA/Dec of the center of each field is mapped to the proper field id
2. Test three coordinates inside specific fields at declinations -2, -30 and -85
3. Generate a set of random coordinates and make sure they are all assigned a field id. 
