### PR TITLE
Feature/altazbatch

### DIFF
--- a/bin.src/run_all.py
+++ b/bin.src/run_all.py
@@ -55,9 +55,6 @@ def setBatches(opsdb, colmap, args):
         bdict.update(batches.tEffMetrics(colmap, args.runName, extraSql=sqls[tag],
                                          extraMetadata=metadata[tag]))
 
-    # NVisits alt/az HealpixSkyMap (all filters, per filter)
-    bdict.update(batches.altazHealBatch(colmap, args.runName, extraSql=args.sqlConstraint))
-
     # NVisits alt/az LambertSkyMap (all filters, per filter)
     bdict.update(batches.altazLambBatch(colmap, args.runName, extraSql=args.sqlConstraint))
 

--- a/bin.src/run_all.py
+++ b/bin.src/run_all.py
@@ -24,7 +24,7 @@ def setBatches(opsdb, colmap, args):
     """
     for tag in ['All', 'WFD']:
         sql = sqls[tag]
-        md = metadata[tag]    
+        md = metadata[tag]
         fO = batches.fOBatch(colmap=colmap, runName=args.runName,
                              extraSql=sql, extraMetadata=md)
         bdict.update(fO)
@@ -34,7 +34,7 @@ def setBatches(opsdb, colmap, args):
         rapidrevisit = batches.rapidRevisitBatch(colmap=colmap, runName=args.runName,
                                                  extraSql=sql, extraMetadata=md)
         bdict.update(rapidrevisit)
-    bdict.update(batches.glanceBatch(colmap=colmap, runName=args.runName, sqlConstraint=args.sqlConstraint))    
+    bdict.update(batches.glanceBatch(colmap=colmap, runName=args.runName, sqlConstraint=args.sqlConstraint))
     bdict.update(batches.intraNight(colmap, args.runName, extraSql=args.sqlConstraint))
     bdict.update(batches.interNight(colmap, args.runName, extraSql=args.sqlConstraint))
     """
@@ -54,6 +54,12 @@ def setBatches(opsdb, colmap, args):
                                            extraSql=sqls[tag], extraMetadata=metadata[tag]))
         bdict.update(batches.tEffMetrics(colmap, args.runName, extraSql=sqls[tag],
                                          extraMetadata=metadata[tag]))
+
+    # NVisits alt/az HealpixSkyMap (all filters, per filter)
+    bdict.update(batches.altazHealBatch(colmap, args.runName, extraSql=args.sqlConstraint))
+
+    # NVisits alt/az LambertSkyMap (all filters, per filter)
+    bdict.update(batches.altazLambBatch(colmap, args.runName, extraSql=args.sqlConstraint))
 
     # Slew metrics.
     bdict.update(batches.slewBasics(colmap, args.runName, sqlConstraint=args.sqlConstraint))

--- a/bin.src/run_altaz.py
+++ b/bin.src/run_altaz.py
@@ -11,9 +11,6 @@ from run_generic import *
 def setBatches(opsdb, colmap, args):
     bdict = {}
 
-    # NVisits alt/az HealpixSkyMap (all filters, per filter)
-    bdict.update(batches.altazHealBatch(colmap, args.runName, extraSql=args.sqlConstraint))
-
     # NVisits alt/az LambertSkyMap (all filters, per filter)
     bdict.update(batches.altazLambBatch(colmap, args.runName, extraSql=args.sqlConstraint))
 

--- a/bin.src/run_altaz.py
+++ b/bin.src/run_altaz.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import matplotlib
+matplotlib.use('Agg')
+import lsst.sims.maf.batches as batches
+from run_generic import *
+
+
+def setBatches(opsdb, colmap, args):
+    bdict = {}
+
+    # NVisits alt/az HealpixSkyMap (all filters, per filter)
+    bdict.update(batches.altazHealBatch(colmap, args.runName, extraSql=args.sqlConstraint))
+
+    # NVisits alt/az LambertSkyMap (all filters, per filter)
+    bdict.update(batches.altazLambBatch(colmap, args.runName, extraSql=args.sqlConstraint))
+
+    return bdict
+
+
+if __name__ == '__main__':
+    args = parseArgs(subdir = 'altaz')
+    opsdb, colmap = connectDb(args.dbfile)
+    bdict = setBatches(opsdb, colmap, args)
+    if args.plotOnly:
+        replot(bdict, opsdb, colmap, args)
+    else:
+        run(bdict, opsdb, colmap, args)
+    opsdb.close()

--- a/python/lsst/sims/maf/batches/__init__.py
+++ b/python/lsst/sims/maf/batches/__init__.py
@@ -8,3 +8,4 @@ from .visitdepthBatch import *
 from .hourglassBatch import *
 from .glanceBatch import *
 from .filterchangeBatch import *
+from .altazBatch import *

--- a/python/lsst/sims/maf/batches/altazBatch.py
+++ b/python/lsst/sims/maf/batches/altazBatch.py
@@ -107,7 +107,6 @@ def altazLambBatch(colmap=None, runName='opsim', extraSql=None,
 
     bundleList = []
 
-    plotDict = {}
     plotFunc = plots.LambertSkyMap()
 
     for f in filterlist:
@@ -118,7 +117,7 @@ def altazLambBatch(colmap=None, runName='opsim', extraSql=None,
         displayDict = {'group': 'Alt/Az', 'order': orders[f], 'subgroup': subgroup,
                        'caption':
                        'Alt/Az pointing distribution for filter %s' % f}
-        bundle = mb.MetricBundle(metric, slicer, sqls[f], plotDict=plotDict,
+        bundle = mb.MetricBundle(metric, slicer, sqls[f],
                                  runName=runName, metadata = metadata[f],
                                  plotFuncs=[plotFunc], displayDict=displayDict)
         bundleList.append(bundle)

--- a/python/lsst/sims/maf/batches/altazBatch.py
+++ b/python/lsst/sims/maf/batches/altazBatch.py
@@ -18,8 +18,8 @@ def basicSetup(metricName, colmap=None, nside=64):
 
     return colmap, slicer, metric
 
-def altazHealBatch(colmap=None, runName='opsim', groupName=None,
-                   extraSql=None, extraMetadata=None, metricName='NVisits Alt/Az'):
+def altazHealBatch(colmap=None, runName='opsim', extraSql=None,
+                   extraMetadata=None, metricName='NVisits Alt/Az'):
 
     """Generate a set of metrics measuring the number visits as a function of alt/az
     plotted on a HealpixSkyMap.
@@ -30,8 +30,6 @@ def altazHealBatch(colmap=None, runName='opsim', groupName=None,
         A dictionary with a mapping of column names. Default will use OpsimV4 column names.
     runName : str, opt
         The name of the simulated survey. Default is "opsim".
-    groupName : str, opt
-        The group name for this quantity in the displayDict. Default is the same as 'valueName', capitalized.
     extraSql : str, opt
         Additional constraint to add to any sql constraints (e.g. 'propId=1' or 'fieldID=522').
         Default None, for no additional constraints.
@@ -75,8 +73,8 @@ def altazHealBatch(colmap=None, runName='opsim', groupName=None,
     return mb.makeBundlesDictFromList(bundleList)
 
 
-def altazLambBatch(colmap=None, runName='opsim', groupName=None,
-                   extraSql=None, extraMetadata=None, metricName='Nvisits as function of Alt/Az'):
+def altazLambBatch(colmap=None, runName='opsim', extraSql=None,
+                   extraMetadata=None, metricName='Nvisits as function of Alt/Az'):
 
     """Generate a set of metrics measuring the number visits as a function of alt/az
     plotted on a LambertSkyMap.
@@ -87,8 +85,6 @@ def altazLambBatch(colmap=None, runName='opsim', groupName=None,
         A dictionary with a mapping of column names. Default will use OpsimV4 column names.
     runName : str, opt
         The name of the simulated survey. Default is "opsim".
-    groupName : str, opt
-        The group name for this quantity in the displayDict. Default is the same as 'valueName', capitalized.
     extraSql : str, opt
         Additional constraint to add to any sql constraints (e.g. 'propId=1' or 'fieldID=522').
         Default None, for no additional constraints.

--- a/python/lsst/sims/maf/batches/altazBatch.py
+++ b/python/lsst/sims/maf/batches/altazBatch.py
@@ -60,7 +60,7 @@ def altazHealBatch(colmap=None, runName='opsim', extraSql=None,
             subgroup = 'All Observations'
         else:
             subgroup = 'Per filter'
-        displayDict = {'group': 'Hour Angle', 'order': orders[f], 'subgroup': subgroup,
+        displayDict = {'group': 'Alt/Az', 'order': orders[f], 'subgroup': subgroup,
                        'caption':
                        'Pointing History on the alt-az sky (zenith center) for filter %s' % f}
         bundle = mb.MetricBundle(metric, slicer, sqls[f], plotDict=plotDict,
@@ -115,9 +115,9 @@ def altazLambBatch(colmap=None, runName='opsim', extraSql=None,
             subgroup = 'All Observations'
         else:
             subgroup = 'Per filter'
-        displayDict = {'group': 'Alt Az', 'order': orders[f], 'subgroup': subgroup,
+        displayDict = {'group': 'Alt/Az', 'order': orders[f], 'subgroup': subgroup,
                        'caption':
-                       'Alt Az pointing distribution for filter %s' % f}
+                       'Alt/Az pointing distribution for filter %s' % f}
         bundle = mb.MetricBundle(metric, slicer, sqls[f], plotDict=plotDict,
                                  runName=runName, metadata = metadata[f],
                                  plotFuncs=[plotFunc], displayDict=displayDict)

--- a/python/lsst/sims/maf/batches/altazBatch.py
+++ b/python/lsst/sims/maf/batches/altazBatch.py
@@ -1,0 +1,132 @@
+import lsst.sims.maf.metrics as metrics
+import lsst.sims.maf.slicers as slicers
+import lsst.sims.maf.metricBundles as mb
+import lsst.sims.maf.plots as plots
+from .colMapDict import ColMapDict
+from .common import standardSummary, extendedMetrics, filterList
+
+__all__ = ['altazHealBatch','altazLambBatch']
+
+def basicSetup(metricName, colmap=None, nside=64):
+
+    if colmap is None:
+        colmap = ColMapDict('opsimV4')
+
+    slicer = slicers.HealpixSlicer(nside=nside, latCol=colmap['alt'], lonCol=colmap['az'],
+                                   latLonDeg=colmap['raDecDeg'], useCache=False)
+    metric = metrics.CountMetric(colmap['mjd'], metricName=metricName)
+
+    return colmap, slicer, metric
+
+def altazHealBatch(colmap=None, runName='opsim', groupName=None,
+                   extraSql=None, extraMetadata=None, metricName='NVisits Alt/Az'):
+
+    """Generate a set of metrics measuring the number visits as a function of alt/az
+    plotted on a HealpixSkyMap.
+
+    Parameters
+    ----------
+    colmap : dict, opt
+        A dictionary with a mapping of column names. Default will use OpsimV4 column names.
+    runName : str, opt
+        The name of the simulated survey. Default is "opsim".
+    groupName : str, opt
+        The group name for this quantity in the displayDict. Default is the same as 'valueName', capitalized.
+    extraSql : str, opt
+        Additional constraint to add to any sql constraints (e.g. 'propId=1' or 'fieldID=522').
+        Default None, for no additional constraints.
+    extraMetadata : str, opt
+        Additional metadata to add before any below (i.e. "WFD").  Default is None.
+    metricName : str, opt
+        Unique name to assign to metric
+
+    Returns
+    -------
+    metricBundleDict
+    """
+
+    colmap, slicer, metric = basicSetup(metricName=metricName, colmap=colmap)
+
+    # Set up basic all and per filter sql constraints.
+    filterlist, colors, orders, sqls, metadata = filterList(all=True,
+                                                            extraSql=extraSql,
+                                                            extraMetadata=extraMetadata)
+
+    bundleList = []
+
+    plotDict = {'rot': (90, 90, 90), 'flip': 'geo'}
+    plotFunc = plots.HealpixSkyMap()
+
+    for f in filterlist:
+        if f is 'all':
+            subgroup = 'All Observations'
+        else:
+            subgroup = 'Per filter'
+        displayDict = {'group': 'Hour Angle', 'order': orders[f], 'subgroup': subgroup,
+                       'caption':
+                       'Pointing History on the alt-az sky (zenith center) for filter %s' % f}
+        bundle = mb.MetricBundle(metric, slicer, sqls[f], plotDict=plotDict,
+                                 runName=runName, metadata = metadata[f],
+                                 plotFuncs=[plotFunc], displayDict=displayDict)
+        bundleList.append(bundle)
+
+    for b in bundleList:
+        b.setRunName(runName)
+    return mb.makeBundlesDictFromList(bundleList)
+
+
+def altazLambBatch(colmap=None, runName='opsim', groupName=None,
+                   extraSql=None, extraMetadata=None, metricName='Nvisits as function of Alt/Az'):
+
+    """Generate a set of metrics measuring the number visits as a function of alt/az
+    plotted on a LambertSkyMap.
+
+    Parameters
+    ----------
+    colmap : dict, opt
+        A dictionary with a mapping of column names. Default will use OpsimV4 column names.
+    runName : str, opt
+        The name of the simulated survey. Default is "opsim".
+    groupName : str, opt
+        The group name for this quantity in the displayDict. Default is the same as 'valueName', capitalized.
+    extraSql : str, opt
+        Additional constraint to add to any sql constraints (e.g. 'propId=1' or 'fieldID=522').
+        Default None, for no additional constraints.
+    extraMetadata : str, opt
+        Additional metadata to add before any below (i.e. "WFD").  Default is None.
+    metricName : str, opt
+        Unique name to assign to metric
+
+    Returns
+    -------
+    metricBundleDict
+    """
+
+    colmap, slicer, metric = basicSetup(metricName=metricName, colmap=colmap)
+
+    # Set up basic all and per filter sql constraints.
+    filterlist, colors, orders, sqls, metadata = filterList(all=True,
+                                                            extraSql=extraSql,
+                                                            extraMetadata=extraMetadata)
+
+    bundleList = []
+
+    plotDict = {}
+    plotFunc = plots.LambertSkyMap()
+
+    for f in filterlist:
+        if f is 'all':
+            subgroup = 'All Observations'
+        else:
+            subgroup = 'Per filter'
+        displayDict = {'group': 'Alt Az', 'order': orders[f], 'subgroup': subgroup,
+                       'caption':
+                       'Alt Az pointing distribution for filter %s' % f}
+        bundle = mb.MetricBundle(metric, slicer, sqls[f], plotDict=plotDict,
+                                 runName=runName, metadata = metadata[f],
+                                 plotFuncs=[plotFunc], displayDict=displayDict)
+        bundleList.append(bundle)
+
+    for b in bundleList:
+        b.setRunName(runName)
+    return mb.makeBundlesDictFromList(bundleList)


### PR DESCRIPTION
A small PR to add a new batch to produce the NVisits as a function of alt/az maps. For simplicity the batch has two separate methods for creating the `HealpixSkyMaps` and the `LambertSkyMaps`. Each method calculates the metric for all observations and on a per filter basis. I have also created the `run_altaz.py` script and added the new batch to the `run_all.py` script.