### PR TITLE
U/danielsf/random rot dither/seed

### DIFF
--- a/tests/diagnose/testPS.py
+++ b/tests/diagnose/testPS.py
@@ -7,6 +7,7 @@ import lsst.sims.maf.metrics as metrics
 import lsst.sims.maf.binners as binners
 import lsst.sims.maf.binMetrics as binMetrics
 
+rng = np.random.RandomState(800233)
 
 oo = db.OpsimDatabase('sqlite:///opsimblitz1_1131_sqlite.db')
 
@@ -20,7 +21,7 @@ hexbinner = binners.HealpixBinner(nside=nside, spatialkey1='hexdithra', spatialk
 hexbinner.setupBinner(simdata)
 
 # Generate random values over the entire sky
-randomallskymetricval = ma.MaskedArray(data = np.random.rand(len(binner)),
+randomallskymetricval = ma.MaskedArray(data = rng.rand(len(binner)),
                                        mask = np.zeros(len(binner), bool), 
                                        fill_value= binner.badval)
 
@@ -40,10 +41,10 @@ hexgm.setBinner(hexbinner)
 hexgm.setMetrics([metric])
 hexgm.runBins(simdata, 'test')
 
-randomnodithermetricval = ma.MaskedArray(data = np.random.rand(len(binner)),
+randomnodithermetricval = ma.MaskedArray(data = rng.rand(len(binner)),
                                          mask = gm.metricValues[gm.metricNames[0]].mask,
                                          fill_value = binner.badval)
-randomhexdithermetricval = ma.MaskedArray(data = np.random.rand(len(binner)),
+randomhexdithermetricval = ma.MaskedArray(data = rng.rand(len(binner)),
                                           mask = hexgm.metricValues[hexgm.metricNames[0]].mask,
                                           fill_value = hexbinner.badval)
 

--- a/tests/testBatchCommon.py
+++ b/tests/testBatchCommon.py
@@ -11,7 +11,7 @@ class TestCommon(unittest.TestCase):
         self.assertEqual(len(colors), 6)
         self.assertEqual(sqls['u'], 'filter = "u"')
         filterlist, colors, orders, sqls, metadata = batches.common.filterList(all=True, extraSql=None)
-        self.assertTrue('all' in filterlist)
+        self.assertIn('all', filterlist)
         self.assertEqual(sqls['all'], '')
         filterlist, colors, orders, sqls, metadata = batches.common.filterList(all=True, extraSql='night=3')
         self.assertEqual(sqls['all'], 'night=3')

--- a/tests/testCadenceMetrics.py
+++ b/tests/testCadenceMetrics.py
@@ -184,8 +184,9 @@ class TestCadenceMetrics(unittest.TestCase):
         # Let's see how much dmax/result can vary
         resmin = 1
         resmax = 0
+        rng = np.random.RandomState(88123100)
         for i in range(10000):
-            dtimes = np.random.rand(100)
+            dtimes = rng.rand(100)
             data['observationStartMJD'] = dtimes.cumsum()
             metric = metrics.RapidRevisitMetric(dTmin=0.1, dTmax=0.8, minNvisits=50)
             result = metric.run(data)

--- a/tests/testCadenceMetrics.py
+++ b/tests/testCadenceMetrics.py
@@ -153,13 +153,13 @@ class TestCadenceMetrics(unittest.TestCase):
         # All nights have one visit.
         expected_result = np.zeros(len(bins) - 1, dtype=int)
         expected_result[1] = len(data)
-        self.assertTrue(np.all(result == expected_result))
+        np.testing.assert_array_equal(result, expected_result)
 
         data['night'] = np.floor(np.arange(0, 100) / 2)
         result = metric.run(data)
         expected_result = np.zeros(len(bins) - 1, dtype=int)
         expected_result[2] = len(data) / 2
-        self.assertTrue(np.all(result == expected_result))
+        np.testing.assert_array_equal(result, expected_result)
 
     def testRapidRevisitMetric(self):
         data = np.zeros(100, dtype=list(zip(['observationStartMJD'], [float])))
@@ -170,17 +170,17 @@ class TestCadenceMetrics(unittest.TestCase):
         metric = metrics.RapidRevisitMetric(dTmin=5, dTmax=55, minNvisits=50)
         result = metric.run(data)
         # This should be uniform.
-        self.assertTrue(result < 0.1)
-        self.assertTrue(result >= 0)
+        self.assertLess(result, 0.1)
+        self.assertGreaterEqual(result, 0)
         # Set up non-uniform distribution of time differences
         dtimes = np.zeros(100) + 5
         data['observationStartMJD'] = dtimes.cumsum()
         result = metric.run(data)
-        self.assertTrue(result >= 0.5)
+        self.assertGreaterEqual(result, 0.5)
         dtimes = np.zeros(100) + 15
         data['observationStartMJD'] = dtimes.cumsum()
         result = metric.run(data)
-        self.assertTrue(result >= 0.5)
+        self.assertGreaterEqual(result, 0.5)
         # Let's see how much dmax/result can vary
         resmin = 1
         resmax = 0

--- a/tests/testCalibrationMetrics.py
+++ b/tests/testCalibrationMetrics.py
@@ -167,12 +167,12 @@ class TestCalibrationMetrics(unittest.TestCase):
         np.testing.assert_almost_equal(val, 0., decimal=2)
 
         # Generate a random distribution that should have little or no correlation
-        np.random.seed(42)
+        rng = np.random.RandomState(42)
 
-        data['ra_pi_amp'] = np.random.rand(100)*2-1.
-        data['dec_pi_amp'] = np.random.rand(100)*2-1.
-        data['ra_dcr_amp'] = np.random.rand(100)*2-1.
-        data['dec_dcr_amp'] = np.random.rand(100)*2-1.
+        data['ra_pi_amp'] = rng.rand(100)*2-1.
+        data['dec_pi_amp'] = rng.rand(100)*2-1.
+        data['ra_dcr_amp'] = rng.rand(100)*2-1.
+        data['dec_dcr_amp'] = rng.rand(100)*2-1.
 
         val = metric.run(data)
         assert(np.abs(val) < 0.2)

--- a/tests/testHealpixSlicer.py
+++ b/tests/testHealpixSlicer.py
@@ -11,7 +11,7 @@ import lsst.utils.tests
 
 
 def makeDataValues(size=100, minval=0., maxval=1., ramin=0, ramax=2*np.pi,
-                   decmin=-np.pi, decmax=np.pi, random=True):
+                   decmin=-np.pi, decmax=np.pi, random=1172):
     """Generate a simple array of numbers, evenly arranged between min/max,
     in 1 dimensions (optionally sorted), together with RA/Dec values
     for each data value."""
@@ -20,33 +20,31 @@ def makeDataValues(size=100, minval=0., maxval=1., ramin=0, ramax=2*np.pi,
     datavalues = np.arange(0, size, dtype='float')
     datavalues *= (float(maxval) - float(minval)) / (datavalues.max() - datavalues.min())
     datavalues += minval
-    if random:
-        randorder = np.random.rand(size)
-        randind = np.argsort(randorder)
-        datavalues = datavalues[randind]
+    rng = np.random.RandomState(random)
+    randorder = rng.rand(size)
+    randind = np.argsort(randorder)
+    datavalues = datavalues[randind]
     datavalues = np.array(list(zip(datavalues)), dtype=[('testdata', 'float')])
     data.append(datavalues)
     # Generate RA/Dec values equally spaces on sphere between ramin/max, decmin/max.
     ra = np.arange(0, size, dtype='float')
     ra *= (float(ramax) - float(ramin)) / (ra.max() - ra.min())
-    if random:
-        randorder = np.random.rand(size)
-        randind = np.argsort(randorder)
-        ra = ra[randind]
+    randorder = rng.rand(size)
+    randind = np.argsort(randorder)
+    ra = ra[randind]
     ra = np.array(list(zip(ra)), dtype=[('ra', 'float')])
     data.append(ra)
     v = np.arange(0, size, dtype='float')
     v *= ((np.cos(decmax+np.pi) + 1.)/2.0 - (np.cos(decmin+np.pi)+1.)/2.0) / (v.max() - v.min())
     v += (np.cos(decmin+np.pi)+1.)/2.0
     dec = np.arccos(2*v-1) - np.pi
-    if random:
-        randorder = np.random.rand(size)
-        randind = np.argsort(randorder)
-        dec = dec[randind]
+    randorder = rng.rand(size)
+    randind = np.argsort(randorder)
+    dec = dec[randind]
     dec = np.array(list(zip(dec)), dtype=[('dec', 'float')])
     data.append(dec)
     # Add in rotation angle
-    rot = np.random.rand(len(dec))*2*np.pi
+    rot = rng.rand(len(dec))*2*np.pi
     data.append(np.array(rot, dtype=[('rotSkyPos', 'float')]))
     mjd = np.arange(len(dec))*.1
     data.append(np.array(mjd, dtype=[('observationStartMJD', 'float')]))
@@ -98,7 +96,7 @@ class TestHealpixSlicerEqual(unittest.TestCase):
         self.dv = makeDataValues(size=nvalues, minval=0., maxval=1.,
                                  ramin=0, ramax=2*np.pi,
                                  decmin=-np.pi, decmax=0,
-                                 random=True)
+                                 random=22)
         self.testslicer.setupSlicer(self.dv)
 
     def tearDown(self):
@@ -126,7 +124,7 @@ class TestHealpixSlicerIteration(unittest.TestCase):
         self.dv = makeDataValues(size=nvalues, minval=0., maxval=1.,
                                  ramin=0, ramax=2*np.pi,
                                  decmin=-np.pi, decmax=0,
-                                 random=True)
+                                 random=33)
         self.testslicer.setupSlicer(self.dv)
 
     def tearDown(self):
@@ -167,7 +165,7 @@ class TestHealpixSlicerSlicing(unittest.TestCase):
         self.dv = makeDataValues(size=nvalues, minval=0., maxval=1.,
                                  ramin=0, ramax=2*np.pi,
                                  decmin=-np.pi, decmax=0,
-                                 random=True)
+                                 random=44)
 
     def tearDown(self):
         del self.testslicer
@@ -206,7 +204,7 @@ class TestHealpixChipGap(unittest.TestCase):
         self.dv = makeDataValues(size=nvalues, minval=0., maxval=1.,
                                  ramin=0, ramax=2*np.pi,
                                  decmin=-np.pi, decmax=0,
-                                 random=True)
+                                 random=55)
 
     def tearDown(self):
         del self.testslicer
@@ -233,6 +231,7 @@ class TestHealpixChipGap(unittest.TestCase):
 class TestHealpixSlicerPlotting(unittest.TestCase):
 
     def setUp(self):
+        rng = np.random.RandomState(713244122)
         self.nside = 16
         self.radius = 1.8
         self.testslicer = HealpixSlicer(nside=self.nside, verbose=False, latLonDeg=False,
@@ -241,7 +240,7 @@ class TestHealpixSlicerPlotting(unittest.TestCase):
         self.dv = makeDataValues(size=nvalues, minval=0., maxval=1.,
                                  ramin=0, ramax=2*np.pi,
                                  decmin=-np.pi, decmax=0,
-                                 random=True)
+                                 random=66)
         self.testslicer.setupSlicer(self.dv)
         self.metricdata = ma.MaskedArray(data=np.zeros(len(self.testslicer), dtype='float'),
                                          mask=np.zeros(len(self.testslicer), 'bool'),
@@ -252,7 +251,7 @@ class TestHealpixSlicerPlotting(unittest.TestCase):
                 self.metricdata.data[i] = np.mean(self.dv['testdata'][idxs])
             else:
                 self.metricdata.mask[i] = True
-        self.metricdata2 = ma.MaskedArray(data=np.random.rand(len(self.testslicer)),
+        self.metricdata2 = ma.MaskedArray(data=rng.rand(len(self.testslicer)),
                                           mask=np.zeros(len(self.testslicer), 'bool'),
                                           fill_value=self.testslicer.badval)
 

--- a/tests/testHealpixSlicer.py
+++ b/tests/testHealpixSlicer.py
@@ -222,10 +222,10 @@ class TestHealpixChipGap(unittest.TestCase):
             distances = calcDist_vincenty(ra, dec, self.dv['ra'], self.dv['dec'])
             didxs = np.where(distances <= np.radians(self.radius))
             sidxs = s['idxs']
-            self.assertTrue(len(sidxs) <= len(didxs[0]))
+            self.assertLessEqual(len(sidxs), len(didxs[0]))
             if len(sidxs) > 0:
                 for indx in sidxs:
-                    self.assertTrue(self.dv['testdata'][indx] in self.dv['testdata'][didxs])
+                    self.assertIn(self.dv['testdata'][indx], self.dv['testdata'][didxs])
 
 
 class TestHealpixSlicerPlotting(unittest.TestCase):

--- a/tests/testJSON.py
+++ b/tests/testJSON.py
@@ -9,21 +9,23 @@ import lsst.sims.maf.slicers as slicers
 import lsst.utils.tests
 
 
-def makeDataValues(size=100, min=0., max=1., random=True):
+def makeDataValues(size=100, min=0., max=1., random=-1):
     """Generate a simple array of numbers, evenly arranged between min/max, but (optional) random order."""
     datavalues = np.arange(0, size, dtype='float')
     datavalues *= (float(max) - float(min)) / (datavalues.max() - datavalues.min())
     datavalues += min
-    if random:
-        randorder = np.random.rand(size)
+    if random>0:
+        rng = np.random.RandomState(random)
+        randorder = rng.rand(size)
         randind = np.argsort(randorder)
         datavalues = datavalues[randind]
     datavalues = np.array(list(zip(datavalues)), dtype=[('testdata', 'float')])
     return datavalues
 
 
-def makeMetricData(slicer, dtype='float'):
-    metricValues = np.random.rand(len(slicer)).astype(dtype)
+def makeMetricData(slicer, dtype='float', seed=8800):
+    rng = np.random.RandomState(seed)
+    metricValues = rng.rand(len(slicer)).astype(dtype)
     metricValues = ma.MaskedArray(data=metricValues,
                                   mask=np.zeros(len(slicer), 'bool'),
                                   fill_value=slicer.badval)
@@ -50,18 +52,18 @@ def makeFieldData():
     return fieldData
 
 
-def makeOpsimDataValues(fieldData, size=10000, min=0., max=1., random=True):
+def makeOpsimDataValues(fieldData, size=10000, min=0., max=1., random=88):
     """Generate a simple array of numbers, evenly arranged between min/max, but (optional) random order."""
     datavalues = np.arange(0, size, dtype='float')
     datavalues *= (float(max) - float(min)) / (datavalues.max() - datavalues.min())
     datavalues += min
-    if random:
-        randorder = np.random.rand(size)
-        randind = np.argsort(randorder)
-        datavalues = datavalues[randind]
+    rng = np.random.RandomState(random)
+    randorder = rng.rand(size)
+    randind = np.argsort(randorder)
+    datavalues = datavalues[randind]
     # Add valid fieldId values to match data values
     fieldId = np.zeros(len(datavalues), 'int')
-    idxs = np.random.rand(size) * len(fieldData['fieldId'])
+    idxs = rng.rand(size) * len(fieldData['fieldId'])
     for i, d in enumerate(datavalues):
         fieldId[i] = fieldData[int(idxs[i])][0]
     simData = np.core.records.fromarrays([fieldId, datavalues], names=['fieldId', 'testdata'])
@@ -78,7 +80,7 @@ class TestJSONoutUniSlicer(unittest.TestCase):
 
     @unittest.skip("13 March 2017--Skipping to clear python 3 update. Probably string unicode issues.")
     def test(self):
-        metricVal = makeMetricData(self.testslicer, 'float')
+        metricVal = makeMetricData(self.testslicer, 'float', seed=88102231)
         io = self.testslicer.outputJSON(metricVal, metricName='testMetric',
                                         simDataName='testSim', metadata='testmeta')
         jsn = json.loads(io.getvalue())
@@ -96,7 +98,7 @@ class TestJSONoutOneDSlicer2(unittest.TestCase):
 
     def setUp(self):
         # Set up a slicer and some metric data for that slicer.
-        dv = makeDataValues(1000)
+        dv = makeDataValues(1000, random=40082)
         self.testslicer = slicers.OneDSlicer(sliceColName='testdata')
         self.testslicer.setupSlicer(dv)
 
@@ -105,7 +107,7 @@ class TestJSONoutOneDSlicer2(unittest.TestCase):
 
     @unittest.skip("13 March 2017--Skipping to clear python 3 update. Probably string unicode issues.")
     def test(self):
-        metricVal = makeMetricData(self.testslicer, 'float')
+        metricVal = makeMetricData(self.testslicer, 'float', seed=18)
         io = self.testslicer.outputJSON(metricVal)
         jsn = json.loads(io.getvalue())
         jsn_header = jsn[0]
@@ -129,7 +131,7 @@ class TestJSONoutHealpixSlicer(unittest.TestCase):
 
     @unittest.skip("13 March 2017--Skipping to clear python 3 update. Probably string unicode issues.")
     def test(self):
-        metricVal = makeMetricData(self.testslicer, 'float')
+        metricVal = makeMetricData(self.testslicer, 'float', seed=452)
         io = self.testslicer.outputJSON(metricVal)
         jsn = json.loads(io.getvalue())
         jsn_header = jsn[0]
@@ -150,7 +152,7 @@ class TestJSONoutOpsimFieldSlicer(unittest.TestCase):
         # Set up a slicer and some metric data for that slicer.
         self.testslicer = slicers.OpsimFieldSlicer()
         self.fieldData = makeFieldData()
-        self.simData = makeOpsimDataValues(self.fieldData)
+        self.simData = makeOpsimDataValues(self.fieldData, random=7162)
         self.testslicer.setupSlicer(self.simData, self.fieldData)
 
     def tearDown(self):
@@ -158,7 +160,7 @@ class TestJSONoutOpsimFieldSlicer(unittest.TestCase):
 
     @unittest.skip("13 March 2017--Skipping to clear python 3 update. Probably string unicode issues.")
     def test(self):
-        metricVal = makeMetricData(self.testslicer, 'float')
+        metricVal = makeMetricData(self.testslicer, 'float', seed=334)
         io = self.testslicer.outputJSON(metricVal)
         jsn = json.loads(io.getvalue())
         jsn_header = jsn[0]

--- a/tests/testMaps.py
+++ b/tests/testMaps.py
@@ -72,7 +72,7 @@ class TestMaps(unittest.TestCase):
             with warnings.catch_warnings(record=True) as w:
                 warnings.simplefilter("always")
                 dustmap.run(slicer1.slicePoints)
-                self.assertTrue("nside" in str(w[-1].message))
+                self.assertIn("nside", str(w[-1].message))
         else:
             warnings.warn('Did not find dustmaps, not running testMaps.py')
 

--- a/tests/testMaps.py
+++ b/tests/testMaps.py
@@ -11,13 +11,14 @@ import lsst.sims.maf.maps as maps
 import lsst.utils.tests
 
 
-def makeDataValues(size=100, min=0., max=1., random=True):
+def makeDataValues(size=100, min=0., max=1., random=-1):
     """Generate a simple array of numbers, evenly arranged between min/max, but (optional) random order."""
     datavalues = np.arange(0, size, dtype='float')
     datavalues *= (float(max) - float(min)) / (datavalues.max() - datavalues.min())
     datavalues += min
-    if random:
-        randorder = np.random.rand(size)
+    if random>0:
+        rng = np.random.RandomState(random)
+        randorder = rng.rand(size)
         randind = np.argsort(randorder)
         datavalues = datavalues[randind]
     ids = np.arange(size)
@@ -27,13 +28,14 @@ def makeDataValues(size=100, min=0., max=1., random=True):
     return datavalues
 
 
-def makeFieldData():
+def makeFieldData(seed):
+    rng = np.random.RandomState(seed)
     names = ['fieldId', 'fieldRA', 'fieldDec']
     types = [int, float, float]
     fieldData = np.zeros(100, dtype=list(zip(names, types)))
     fieldData['fieldId'] = np.arange(100)
-    fieldData['fieldRA'] = np.random.rand(100)
-    fieldData['fieldDec'] = np.random.rand(100)
+    fieldData['fieldRA'] = rng.rand(100)
+    fieldData['fieldDec'] = rng.rand(100)
     return fieldData
 
 
@@ -45,7 +47,7 @@ class TestMaps(unittest.TestCase):
 
         if os.path.isfile(os.path.join(mapPath, 'DustMaps/dust_nside_128.npz')):
 
-            data = makeDataValues()
+            data = makeDataValues(random=981)
             dustmap = maps.DustMap()
 
             slicer1 = slicers.HealpixSlicer(latLonDeg=False)
@@ -53,7 +55,7 @@ class TestMaps(unittest.TestCase):
             result1 = dustmap.run(slicer1.slicePoints)
             assert('ebv' in list(result1.keys()))
 
-            fieldData = makeFieldData()
+            fieldData = makeFieldData(2234)
 
             slicer2 = slicers.OpsimFieldSlicer(latLonDeg=False)
             slicer2.setupSlicer(data, fieldData)
@@ -78,7 +80,7 @@ class TestMaps(unittest.TestCase):
         mapPath = os.environ['SIMS_MAPS_DIR']
 
         if os.path.isfile(os.path.join(mapPath, 'StarMaps/starDensity_r_nside_64.npz')):
-            data = makeDataValues()
+            data = makeDataValues(random=887)
             # check that it works if nside does not match map nside of 64
             nsides = [32, 64, 128]
             for nside in nsides:
@@ -90,7 +92,7 @@ class TestMaps(unittest.TestCase):
                 assert('starLumFunc' in list(result1.keys()))
                 assert(np.max(result1['starLumFunc'] > 0))
 
-            fieldData = makeFieldData()
+            fieldData = makeFieldData(22)
 
             slicer2 = slicers.OpsimFieldSlicer(latLonDeg=False)
             slicer2.setupSlicer(data, fieldData)

--- a/tests/testMoMetrics.py
+++ b/tests/testMoMetrics.py
@@ -82,6 +82,7 @@ class TestMoMetrics1(unittest.TestCase):
 class TestDiscoveryMetrics(unittest.TestCase):
 
     def setUp(self):
+        rng = np.random.RandomState(61331)
         # Set up some ssoObs data to test the metrics on.
         # Note that ssoObs is a numpy recarray.
         # The expected set of columns in ssoObs is:
@@ -124,7 +125,7 @@ class TestDiscoveryMetrics(unittest.TestCase):
         ssoObs['SNR'] = np.zeros(len(times), dtype='float') + 5.0
         ssoObs['vis'] = np.zeros(len(times), dtype='float') + 1
         ssoObs['vis'][0:5] = 0
-        ssoObs['velocity'] = np.random.rand(len(times))
+        ssoObs['velocity'] = rng.rand(len(times))
         ssoObs['FWHMgeom'] = np.ones(len(times), 'float')
         ssoObs['visitExpTime'] = np.ones(len(times), 'float') * 24.0
         self.ssoObs = ssoObs
@@ -177,6 +178,7 @@ class TestDiscoveryMetrics(unittest.TestCase):
 
 
     def testHighVelocityMetric(self):
+        rng = np.random.RandomState(8123)
         velMetric = metrics.HighVelocityMetric(psfFactor=1.0, snrLimit=5)
         metricValue = velMetric.run(self.ssoObs, self.orb, self.Hval)
         self.assertEqual(metricValue, 0)
@@ -186,7 +188,7 @@ class TestDiscoveryMetrics(unittest.TestCase):
         velMetric = metrics.HighVelocityMetric(psfFactor=2.0, snrLimit=5)
         metricValue = velMetric.run(self.ssoObs, self.orb, self.Hval)
         self.assertEqual(metricValue, 0)
-        self.ssoObs['velocity'][0:2] = np.random.rand(1)
+        self.ssoObs['velocity'][0:2] = rng.rand(1)
 
     def testHighVelocityNightsMetric(self):
         velMetric = metrics.HighVelocityNightsMetric(psfFactor=1.0, nObsPerNight=1, snrLimit=5)

--- a/tests/testMovieSlicer.py
+++ b/tests/testMovieSlicer.py
@@ -72,7 +72,7 @@ class TestMovieSlicerSetup(unittest.TestCase):
                                           cumulative=False, forceNoFfmpeg=True)
             self.testslicer.setupSlicer(dv)
             # Verify some things
-            self.assertTrue("binsize" in str(w[-1].message))
+            self.assertIn("binsize", str(w[-1].message))
 
     def testSetupSlicerNbinsZeros(self):
         """Test what happens if give slicer test data that is all single-value."""
@@ -83,7 +83,7 @@ class TestMovieSlicerSetup(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             self.testslicer.setupSlicer(dv)
-            self.assertTrue("creasing binMax" in str(w[-1].message))
+            self.assertIn("creasing binMax", str(w[-1].message))
         self.assertEqual(self.testslicer.nslice, nbins)
 
     def testSetupSlicerLimits(self):
@@ -113,7 +113,7 @@ class TestMovieSlicerSetup(unittest.TestCase):
         for i, (s, b) in enumerate(zip(self.testslicer, bins)):
             self.assertEqual(s['slicePoint']['sid'], i)
             self.assertEqual(s['slicePoint']['binLeft'], b)
-            self.assertTrue(s['slicePoint']['binRight'] <= bins[i+1])
+            self.assertLessEqual(s['slicePoint']['binRight'], bins[i+1])
         for i in ([0, len(self.testslicer)//2, len(self.testslicer)-1]):
             self.assertEqual(self.testslicer[i]['slicePoint']['sid'], i)
             self.assertEqual(self.testslicer[i]['slicePoint']['binLeft'], bins[i])
@@ -176,7 +176,7 @@ class TestMovieSlicerSetup(unittest.TestCase):
             for i, s in enumerate(self.testslicer):
                 idxs = s['idxs']
                 dataslice = dv['times'][idxs]
-                self.assertTrue(len(dataslice) > 0)
+                self.assertGreater(len(dataslice), 0)
 
 
 class TestMemory(lsst.utils.tests.MemoryTestCase):

--- a/tests/testMovieSlicer.py
+++ b/tests/testMovieSlicer.py
@@ -10,13 +10,14 @@ from lsst.sims.maf.slicers.uniSlicer import UniSlicer
 import lsst.utils.tests
 
 
-def makeTimes(size=100, min=0., max=10., random=True):
+def makeTimes(size=100, min=0., max=10., random=-1):
     """Generate a simple array of numbers, evenly arranged between min/max."""
     datavalues = np.arange(0, size, dtype='float')
     datavalues *= (float(max) - float(min)) / (datavalues.max() - datavalues.min())
     datavalues += min
-    if random:
-        randorder = np.random.rand(size)
+    if random>0:
+        rng = np.random.RandomState(random)
+        randorder = rng.rand(size)
         randind = np.argsort(randorder)
         datavalues = datavalues[randind]
     datavalues = np.array(list(zip(datavalues)), dtype=[('times', 'float')])
@@ -43,7 +44,7 @@ class TestMovieSlicerSetup(unittest.TestCase):
         dvmax = 1
         nvalues = 1000
         bins = np.arange(dvmin, dvmax, 0.1)
-        dv = makeTimes(nvalues, dvmin, dvmax)
+        dv = makeTimes(nvalues, dvmin, dvmax, random=987)
         # Used right bins?
         self.testslicer = MovieSlicer(sliceColName='times', bins=bins, cumulative=False, forceNoFfmpeg=True)
         self.testslicer.setupSlicer(dv)
@@ -54,7 +55,7 @@ class TestMovieSlicerSetup(unittest.TestCase):
         """Test setting up slicer using binsize."""
         dvmin = 0
         dvmax = 1
-        dv = makeTimes(1000, dvmin, dvmax)
+        dv = makeTimes(1000, dvmin, dvmax, random=1992)
         binsize = 0.1
         for cumulative in ([True, False]):
             self.testslicer = MovieSlicer(sliceColName='times', binsize=binsize, cumulative=cumulative,
@@ -92,7 +93,7 @@ class TestMovieSlicerSetup(unittest.TestCase):
         nbins = 10
         dvmin = -.5
         dvmax = 1.5
-        dv = makeTimes(1000, dvmin, dvmax)
+        dv = makeTimes(1000, dvmin, dvmax, random=1772)
         self.testslicer = MovieSlicer(sliceColName='times',
                                       binMin=binMin, binMax=binMax, bins=nbins,
                                       cumulative=False, forceNoFfmpeg=True)
@@ -107,7 +108,7 @@ class TestMovieSlicerSetup(unittest.TestCase):
         bins = np.arange(dvmin, dvmax+0.05, 0.05)
         self.testslicer = MovieSlicer(sliceColName='times', bins=bins,
                                       cumulative=False, forceNoFfmpeg=True)
-        dv = makeTimes(1000, dvmin, dvmax)
+        dv = makeTimes(1000, dvmin, dvmax, random=908223)
         self.testslicer.setupSlicer(dv)
         for i, (s, b) in enumerate(zip(self.testslicer, bins)):
             self.assertEqual(s['slicePoint']['sid'], i)
@@ -126,21 +127,21 @@ class TestMovieSlicerSetup(unittest.TestCase):
         dvmax = 1
         nvalues = 1000
         bins = np.arange(dvmin, dvmax, 0.01)
-        dv = makeTimes(nvalues, dvmin, dvmax)
+        dv = makeTimes(nvalues, dvmin, dvmax, random=72031)
         self.testslicer = MovieSlicer(sliceColName='times', bins=bins, cumulative=False, forceNoFfmpeg=True)
         self.testslicer.setupSlicer(dv)
         # Set up another slicer to match (same bins, although not the same data).
-        dv2 = makeTimes(nvalues+100, dvmin, dvmax)
+        dv2 = makeTimes(nvalues+100, dvmin, dvmax, random=56221)
         testslicer2 = MovieSlicer(sliceColName='times', bins=bins, cumulative=False, forceNoFfmpeg=True)
         testslicer2.setupSlicer(dv2)
         self.assertEqual(self.testslicer, testslicer2)
         # Set up another slicer that should not match (different bins)
-        dv2 = makeTimes(nvalues, dvmin+1, dvmax+1)
+        dv2 = makeTimes(nvalues, dvmin+1, dvmax+1, random=542093)
         testslicer2 = MovieSlicer(sliceColName='times', bins=len(bins), cumulative=False, forceNoFfmpeg=True)
         testslicer2.setupSlicer(dv2)
         self.assertNotEqual(self.testslicer, testslicer2)
         # Set up a different kind of slicer that should not match.
-        dv2 = makeTimes(100, 0, 1)
+        dv2 = makeTimes(100, 0, 1, random=16)
         testslicer2 = UniSlicer()
         testslicer2.setupSlicer(dv2)
         self.assertNotEqual(self.testslicer, testslicer2)
@@ -153,7 +154,7 @@ class TestMovieSlicerSetup(unittest.TestCase):
         # Test that testbinner raises appropriate error before it's set up (first time)
         self.assertRaises(NotImplementedError, self.testslicer._sliceSimData, 0)
         for nvalues in (100, 1000):
-            dv = makeTimes(nvalues, dvmin, dvmax)
+            dv = makeTimes(nvalues, dvmin, dvmax, random=82)
             # Test differential case.
             self.testslicer = MovieSlicer(sliceColName='times', bins=nbins, cumulative=False,
                                           forceNoFfmpeg=True)

--- a/tests/testNDSlicer.py
+++ b/tests/testNDSlicer.py
@@ -15,7 +15,7 @@ from lsst.sims.maf.slicers.uniSlicer import UniSlicer
 import lsst.utils.tests
 
 
-def makeDataValues(size=100, min=0., max=1., nd=3, random=True):
+def makeDataValues(size=100, min=0., max=1., nd=3, random=-1):
     """Generate a simple array of numbers, evenly arranged between min/max, in nd dimensions, but (optional)
     random order."""
     data = []
@@ -23,8 +23,9 @@ def makeDataValues(size=100, min=0., max=1., nd=3, random=True):
         datavalues = np.arange(0, size, dtype='float')
         datavalues *= (float(max) - float(min)) / (datavalues.max() - datavalues.min())
         datavalues += min
-        if random:
-            randorder = np.random.rand(size)
+        if random > 0:
+            rng = np.random.RandomState(60923)
+            randorder = rng.rand(size)
             randind = np.argsort(randorder)
             datavalues = datavalues[randind]
         datavalues = np.array(list(zip(datavalues)), dtype=[('testdata' + '%d' % (d), 'float')])
@@ -40,7 +41,7 @@ class TestNDSlicerSetup(unittest.TestCase):
         self.dvmax = 1
         nvalues = 1000
         self.nd = 3
-        self.dv = makeDataValues(nvalues, self.dvmin, self.dvmax, self.nd, random=True)
+        self.dv = makeDataValues(nvalues, self.dvmin, self.dvmax, self.nd, random=608)
         self.dvlist = self.dv.dtype.names
 
     def testSlicertype(self):
@@ -66,7 +67,7 @@ class TestNDSlicerSetup(unittest.TestCase):
         """Test setting up slicer using nbins."""
         for nvalues in (100, 1000):
             for nbins in (5, 25, 74):
-                dv = makeDataValues(nvalues, self.dvmin, self.dvmax, self.nd, random=False)
+                dv = makeDataValues(nvalues, self.dvmin, self.dvmax, self.nd, random=-1)
                 # Right number of bins?
                 # expect one more 'bin' to accomodate last right edge, but nbins accounts for this
                 testslicer = NDSlicer(self.dvlist, binsList=nbins)
@@ -89,7 +90,7 @@ class TestNDSlicerSetup(unittest.TestCase):
 
     def testSetupSlicerNbinsZeros(self):
         """Test handling case of data being single values."""
-        dv = makeDataValues(100, 0, 0, self.nd, random=False)
+        dv = makeDataValues(100, 0, 0, self.nd, random=-1)
         nbins = 10
         testslicer = NDSlicer(self.dvlist, binsList=nbins)
         with warnings.catch_warnings(record=True) as w:
@@ -105,12 +106,12 @@ class TestNDSlicerSetup(unittest.TestCase):
         """Test setting up slicer using defined bins and nbins is equal where expected."""
         for nbins in (20, 105):
             testslicer = NDSlicer(self.dvlist, binsList=nbins)
-            bins = makeDataValues(nbins+1, self.dvmin, self.dvmax, self.nd, random=False)
+            bins = makeDataValues(nbins+1, self.dvmin, self.dvmax, self.nd, random=-1)
             binsList = []
             for i in bins.dtype.names:
                 binsList.append(bins[i])
             for nvalues in (100, 10000):
-                dv = makeDataValues(nvalues, self.dvmin, self.dvmax, self.nd, random=True)
+                dv = makeDataValues(nvalues, self.dvmin, self.dvmax, self.nd, random=64432)
                 testslicer.setupSlicer(dv)
                 for i in range(self.nd):
                     np.testing.assert_allclose(testslicer.bins[i], binsList[i])
@@ -123,7 +124,7 @@ class TestNDSlicerEqual(unittest.TestCase):
         self.dvmax = 1
         nvalues = 1000
         self.nd = 3
-        self.dv = makeDataValues(nvalues, self.dvmin, self.dvmax, self.nd, random=True)
+        self.dv = makeDataValues(nvalues, self.dvmin, self.dvmax, self.nd, random=20367)
         self.dvlist = self.dv.dtype.names
         self.testslicer = NDSlicer(self.dvlist, binsList=100)
         self.testslicer.setupSlicer(self.dv)
@@ -137,24 +138,24 @@ class TestNDSlicerEqual(unittest.TestCase):
         # Note that two ND slicers will be considered equal if they are both the same kind of
         # slicer AND have the same bins in all dimensions.
         # Set up another slicer to match (same bins, although not the same data).
-        dv2 = makeDataValues(100, self.dvmin, self.dvmax, self.nd, random=True)
+        dv2 = makeDataValues(100, self.dvmin, self.dvmax, self.nd, random=10029)
         dvlist = dv2.dtype.names
         testslicer2 = NDSlicer(sliceColList=dvlist, binsList=self.testslicer.bins)
         testslicer2.setupSlicer(dv2)
         self.assertEqual(self.testslicer, testslicer2)
         # Set up another slicer that should not match (different bins)
-        dv2 = makeDataValues(1000, self.dvmin+1, self.dvmax+1, self.nd, random=True)
+        dv2 = makeDataValues(1000, self.dvmin+1, self.dvmax+1, self.nd, random=209837)
         testslicer2 = NDSlicer(sliceColList=dvlist, binsList=100)
         testslicer2.setupSlicer(dv2)
         self.assertNotEqual(self.testslicer, testslicer2)
         # Set up another slicer that should not match (different dimensions)
-        dv2 = makeDataValues(1000, self.dvmin, self.dvmax, self.nd-1, random=True)
+        dv2 = makeDataValues(1000, self.dvmin, self.dvmax, self.nd-1, random=50623)
         testslicer2 = NDSlicer(dv2.dtype.names, binsList=100)
         testslicer2.setupSlicer(dv2)
         self.assertNotEqual(self.testslicer, testslicer2)
         # Set up a different kind of slicer that should not match.
         testslicer2 = UniSlicer()
-        dv2 = makeDataValues(100, 0, 1, random=True)
+        dv2 = makeDataValues(100, 0, 1, random=22310098)
         testslicer2.setupSlicer(dv2)
         self.assertNotEqual(self.testslicer, testslicer2)
 
@@ -166,7 +167,7 @@ class TestNDSlicerIteration(unittest.TestCase):
         self.dvmax = 1
         nvalues = 1000
         self.nd = 3
-        self.dv = makeDataValues(nvalues, self.dvmin, self.dvmax, self.nd, random=True)
+        self.dv = makeDataValues(nvalues, self.dvmin, self.dvmax, self.nd, random=11081)
         self.dvlist = self.dv.dtype.names
         nvalues = 1000
         bins = np.arange(self.dvmin, self.dvmax, 0.1)
@@ -176,7 +177,7 @@ class TestNDSlicerIteration(unittest.TestCase):
             binsList.append(bins)
             # (remember iteration doesn't use the very last bin in 'bins')
             self.iterlist.append(bins[:-1])
-        dv = makeDataValues(nvalues, self.dvmin, self.dvmax, self.nd, random=True)
+        dv = makeDataValues(nvalues, self.dvmin, self.dvmax, self.nd, random=17)
         self.testslicer = NDSlicer(self.dvlist, binsList=binsList)
         self.testslicer.setupSlicer(dv)
 
@@ -203,7 +204,7 @@ class TestNDSlicerSlicing(unittest.TestCase):
         self.dvmax = 1
         nvalues = 1000
         self.nd = 3
-        self.dv = makeDataValues(nvalues, self.dvmin, self.dvmax, self.nd, random=True)
+        self.dv = makeDataValues(nvalues, self.dvmin, self.dvmax, self.nd, random=173)
         self.dvlist = self.dv.dtype.names
         self.testslicer = NDSlicer(self.dvlist)
 
@@ -219,7 +220,7 @@ class TestNDSlicerSlicing(unittest.TestCase):
         binsize = (self.dvmax - self.dvmin) / (float(nbins))
         self.testslicer = NDSlicer(self.dvlist, binsList=nbins)
         for nvalues in (1000, 10000):
-            dv = makeDataValues(nvalues, self.dvmin, self.dvmax, self.nd, random=True)
+            dv = makeDataValues(nvalues, self.dvmin, self.dvmax, self.nd, random=1735)
             self.testslicer.setupSlicer(dv)
             sum = 0
             for i, s in enumerate(self.testslicer):

--- a/tests/testNDSlicer.py
+++ b/tests/testNDSlicer.py
@@ -24,7 +24,7 @@ def makeDataValues(size=100, min=0., max=1., nd=3, random=-1):
         datavalues *= (float(max) - float(min)) / (datavalues.max() - datavalues.min())
         datavalues += min
         if random > 0:
-            rng = np.random.RandomState(60923)
+            rng = np.random.RandomState(random)
             randorder = rng.rand(size)
             randind = np.argsort(randorder)
             datavalues = datavalues[randind]

--- a/tests/testNDSlicer.py
+++ b/tests/testNDSlicer.py
@@ -97,10 +97,8 @@ class TestNDSlicerSetup(unittest.TestCase):
             warnings.simplefilter("always")
             testslicer.setupSlicer(dv)
             self.assertIn('creasing binMax', str(w[-1].message))
-        expectednbins = 1
-        for d in range(self.nd):
-            expectednbins *= (nbins + d)
-        self.assertTrue(testslicer.nslice, expectednbins)
+        expectednbins = nbins ** self.nd
+        self.assertEqual(testslicer.nslice, expectednbins)
 
     def testSetupSlicerEquivalent(self):
         """Test setting up slicer using defined bins and nbins is equal where expected."""

--- a/tests/testNDSlicer.py
+++ b/tests/testNDSlicer.py
@@ -96,7 +96,7 @@ class TestNDSlicerSetup(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             testslicer.setupSlicer(dv)
-            self.assertTrue('creasing binMax' in str(w[-1].message))
+            self.assertIn('creasing binMax', str(w[-1].message))
         expectednbins = 1
         for d in range(self.nd):
             expectednbins *= (nbins + d)
@@ -234,7 +234,7 @@ class TestNDSlicerSlicing(unittest.TestCase):
                         self.assertLessEqual((dataslice[dvname].max() - b), binsize)
                     else:
                         self.assertAlmostEqual((dataslice[dvname].max() - b), binsize)
-                    self.assertTrue(len(dataslice), nvalues/float(nbins))
+                    self.assertEqual(len(dataslice), nvalues/float(nbins))
             # and check that every data value was assigned somewhere.
             self.assertEqual(sum, nvalues)
 

--- a/tests/testNeoDistancePlotter.py
+++ b/tests/testNeoDistancePlotter.py
@@ -10,16 +10,17 @@ import lsst.utils.tests
 class TestNeoDistancePlotter(unittest.TestCase):
 
     def setUp(self):
+        rng = np.random.RandomState(61723009)
         names = ['eclipLat', 'eclipLon', 'MaxGeoDist',
                  'NEOHelioX', 'NEOHelioY', 'filter']
         types = [float]*5
         types.append('|S1')
         npts = 100
         self.metricValues = np.zeros(npts, list(zip(names, types)))
-        self.metricValues['MaxGeoDist'] = np.random.rand(npts)*2.
-        self.metricValues['eclipLat'] = np.random.rand(npts)
-        self.metricValues['NEOHelioX'] = np.random.rand(npts)*3-1.5
-        self.metricValues['NEOHelioY'] = np.random.rand(npts)*3-1.5+1
+        self.metricValues['MaxGeoDist'] = rng.rand(npts)*2.
+        self.metricValues['eclipLat'] = rng.rand(npts)
+        self.metricValues['NEOHelioX'] = rng.rand(npts)*3-1.5
+        self.metricValues['NEOHelioY'] = rng.rand(npts)*3-1.5+1
         self.metricValues['filter'] = 'g'
 
     def testPlotter(self):

--- a/tests/testOneDSlicer.py
+++ b/tests/testOneDSlicer.py
@@ -77,7 +77,7 @@ class TestOneDSlicerSetup(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             self.testslicer.setupSlicer(dv)
-            self.assertTrue("creasing binMax" in str(w[-1].message))
+            self.assertIn("creasing binMax", str(w[-1].message))
         self.assertEqual(self.testslicer.nslice, nbins)
 
     def testSetupSlicerEquivalent(self):
@@ -124,7 +124,7 @@ class TestOneDSlicerSetup(unittest.TestCase):
             self.testslicer = OneDSlicer(sliceColName='testdata', bins=200, binsize=binsize)
             self.testslicer.setupSlicer(dv)
             # Verify some things
-            self.assertTrue("binsize" in str(w[-1].message))
+            self.assertIn("binsize", str(w[-1].message))
 
     def testSetupSlicerFreedman(self):
         """Test that setting up the slicer using bins=None works."""
@@ -230,6 +230,8 @@ class TestOneDSlicerEqual(unittest.TestCase):
 
 class TestOneDSlicerSlicing(unittest.TestCase):
 
+    longMessage = True
+
     def setUp(self):
         self.testslicer = OneDSlicer(sliceColName='testdata')
 
@@ -254,10 +256,10 @@ class TestOneDSlicerSlicing(unittest.TestCase):
                 dataslice = dv['testdata'][idxs]
                 sum += len(idxs)
                 if len(dataslice) > 0:
-                    self.assertTrue(len(dataslice), nvalues/float(nbins))
+                    self.assertEqual(len(dataslice), nvalues/float(nbins))
                 else:
-                    self.assertTrue(len(dataslice) > 0,
-                                    'Data in test case expected to always be > 0 len after slicing')
+                    self.assertGreater(len(dataslice), 0,
+                                       msg='Data in test case expected to always be > 0 len after slicing')
             self.assertTrue(sum, nvalues)
 
 

--- a/tests/testOneDSlicer.py
+++ b/tests/testOneDSlicer.py
@@ -10,13 +10,14 @@ from lsst.sims.maf.slicers.uniSlicer import UniSlicer
 import lsst.utils.tests
 
 
-def makeDataValues(size=100, min=0., max=1., random=True):
+def makeDataValues(size=100, min=0., max=1., random=-1):
     """Generate a simple array of numbers, evenly arranged between min/max, but (optional) random order."""
     datavalues = np.arange(0, size, dtype='float')
     datavalues *= (float(max) - float(min)) / (datavalues.max() - datavalues.min())
     datavalues += min
-    if random:
-        randorder = np.random.rand(size)
+    if random > 0:
+        rng = np.random.RandomState(random)
+        randorder = rng.rand(size)
         randind = np.argsort(randorder)
         datavalues = datavalues[randind]
     datavalues = np.array(list(zip(datavalues)), dtype=[('testdata', 'float')])
@@ -43,7 +44,7 @@ class TestOneDSlicerSetup(unittest.TestCase):
         dvmax = 1
         nvalues = 1000
         bins = np.arange(dvmin, dvmax, 0.1)
-        dv = makeDataValues(nvalues, dvmin, dvmax, random=True)
+        dv = makeDataValues(nvalues, dvmin, dvmax, random=4)
         # Used right bins?
         self.testslicer = OneDSlicer(sliceColName='testdata', bins=bins)
         self.testslicer.setupSlicer(dv)
@@ -56,7 +57,7 @@ class TestOneDSlicerSetup(unittest.TestCase):
             for nbins in (5, 25, 75):
                 dvmin = 0
                 dvmax = 1
-                dv = makeDataValues(nvalues, dvmin, dvmax, random=False)
+                dv = makeDataValues(nvalues, dvmin, dvmax, random=-1)
                 # Right number of bins?
                 # expect two more 'bins' to accomodate padding on left/right
                 self.testslicer = OneDSlicer(sliceColName='testdata', bins=nbins)
@@ -84,10 +85,10 @@ class TestOneDSlicerSetup(unittest.TestCase):
         dvmin = 0
         dvmax = 1
         for nbins in (20, 50, 100, 105):
-            bins = makeDataValues(nbins+1, dvmin, dvmax, random=False)
+            bins = makeDataValues(nbins+1, dvmin, dvmax, random=-1)
             bins = bins['testdata']
             for nvalues in (100, 1000, 10000):
-                dv = makeDataValues(nvalues, dvmin, dvmax, random=True)
+                dv = makeDataValues(nvalues, dvmin, dvmax, random=11)
                 self.testslicer = OneDSlicer(sliceColName='testdata', bins=bins)
                 self.testslicer.setupSlicer(dv)
                 np.testing.assert_allclose(self.testslicer.bins, bins)
@@ -99,7 +100,7 @@ class TestOneDSlicerSetup(unittest.TestCase):
         nbins = 10
         dvmin = -.5
         dvmax = 1.5
-        dv = makeDataValues(1000, dvmin, dvmax, random=True)
+        dv = makeDataValues(1000, dvmin, dvmax, random=342)
         self.testslicer = OneDSlicer(sliceColName='testdata',
                                      binMin=binMin, binMax=binMax, bins=nbins)
         self.testslicer.setupSlicer(dv)
@@ -110,7 +111,7 @@ class TestOneDSlicerSetup(unittest.TestCase):
         """Test setting up slicer using binsize."""
         dvmin = 0
         dvmax = 1
-        dv = makeDataValues(1000, dvmin, dvmax, random=True)
+        dv = makeDataValues(1000, dvmin, dvmax, random=8977)
         # Test basic use.
         binsize = 0.5
         self.testslicer = OneDSlicer(sliceColName='testdata', binsize=binsize)
@@ -129,7 +130,7 @@ class TestOneDSlicerSetup(unittest.TestCase):
         """Test that setting up the slicer using bins=None works."""
         dvmin = 0
         dvmax = 1
-        dv = makeDataValues(1000, dvmin, dvmax, random=True)
+        dv = makeDataValues(1000, dvmin, dvmax, random=2234)
         self.testslicer = OneDSlicer(sliceColName='testdata', bins=None)
         self.testslicer.setupSlicer(dv)
         # How many bins do you expect from optimal binsize?
@@ -146,7 +147,7 @@ class TestOneDSlicerIteration(unittest.TestCase):
         dvmax = 1
         nvalues = 1000
         self.bins = np.arange(dvmin, dvmax, 0.01)
-        dv = makeDataValues(nvalues, dvmin, dvmax, random=True)
+        dv = makeDataValues(nvalues, dvmin, dvmax, random=5678)
         self.testslicer = OneDSlicer(sliceColName='testdata', bins=self.bins)
         self.testslicer.setupSlicer(dv)
 
@@ -185,23 +186,23 @@ class TestOneDSlicerEqual(unittest.TestCase):
         dvmax = 1
         nvalues = 1000
         bins = np.arange(dvmin, dvmax, 0.01)
-        dv = makeDataValues(nvalues, dvmin, dvmax, random=True)
+        dv = makeDataValues(nvalues, dvmin, dvmax, random=32499)
         self.testslicer = OneDSlicer(sliceColName='testdata', bins=bins)
         self.testslicer.setupSlicer(dv)
         # Set up another slicer to match (same bins, although not the same data).
-        dv2 = makeDataValues(nvalues+100, dvmin, dvmax, random=True)
+        dv2 = makeDataValues(nvalues+100, dvmin, dvmax, random=334)
         testslicer2 = OneDSlicer(sliceColName='testdata', bins=bins)
         testslicer2.setupSlicer(dv2)
         self.assertTrue(self.testslicer == testslicer2)
         self.assertFalse(self.testslicer != testslicer2)
         # Set up another slicer that should not match (different bins)
-        dv2 = makeDataValues(nvalues, dvmin+1, dvmax+1, random=True)
+        dv2 = makeDataValues(nvalues, dvmin+1, dvmax+1, random=445)
         testslicer2 = OneDSlicer(sliceColName='testdata', bins=len(bins))
         testslicer2.setupSlicer(dv2)
         self.assertTrue(self.testslicer != testslicer2)
         self.assertFalse(self.testslicer == testslicer2)
         # Set up a different kind of slicer that should not match.
-        dv2 = makeDataValues(100, 0, 1, random=True)
+        dv2 = makeDataValues(100, 0, 1, random=12)
         testslicer2 = UniSlicer()
         testslicer2.setupSlicer(dv2)
         self.assertTrue(self.testslicer != testslicer2)
@@ -244,7 +245,7 @@ class TestOneDSlicerSlicing(unittest.TestCase):
         # Test that testbinner raises appropriate error before it's set up (first time)
         self.assertRaises(NotImplementedError, self.testslicer._sliceSimData, 0)
         for nvalues in (1000, 10000, 100000):
-            dv = makeDataValues(nvalues, dvmin, dvmax, random=True)
+            dv = makeDataValues(nvalues, dvmin, dvmax, random=560)
             self.testslicer = OneDSlicer(sliceColName='testdata', bins=nbins)
             self.testslicer.setupSlicer(dv)
             sum = 0

--- a/tests/testOpsimDb.py
+++ b/tests/testOpsimDb.py
@@ -31,25 +31,25 @@ class TestOpsimDb(unittest.TestCase):
     def testOpsimDbSetup(self):
         """Test opsim specific database class setup/instantiation."""
         # Test tables were connected to.
-        self.assertTrue('SummaryAllProps' in self.oo.tableNames)
+        self.assertIn('SummaryAllProps', self.oo.tableNames)
         self.assertEqual(self.oo.defaultTable, 'SummaryAllProps')
 
     def testOpsimDbMetricData(self):
         """Test queries for sim data. """
         data = self.oo.fetchMetricData(['seeingFwhmEff', ], 'filter="r" and seeingFwhmEff<1.0')
         self.assertEqual(data.dtype.names, ('seeingFwhmEff',))
-        self.assertTrue(data['seeingFwhmEff'].max() <= 1.0)
+        self.assertLessEqual(data['seeingFwhmEff'].max(), 1.0)
 
     def testOpsimDbPropID(self):
         """Test queries for prop ID"""
         propids, propTags = self.oo.fetchPropInfo()
-        self.assertTrue(len(list(propids.keys())) > 0)
-        self.assertTrue(len(propTags['WFD']) > 0)
-        self.assertTrue(len(propTags['DD']) >= 0)
+        self.assertGreater(len(list(propids.keys())), 0)
+        self.assertGreater(len(propTags['WFD']), 0)
+        self.assertGreaterEqual(len(propTags['DD']), 0)
         for w in propTags['WFD']:
-            self.assertTrue(w in propids)
+            self.assertIn(w, propids)
         for d in propTags['DD']:
-            self.assertTrue(d in propids)
+            self.assertIn(d, propids)
 
     def testOpsimDbFields(self):
         """Test queries for field data."""
@@ -67,14 +67,14 @@ class TestOpsimDb(unittest.TestCase):
     def testOpsimDbSimName(self):
         """Test query for opsim name."""
         simname = self.oo.fetchOpsimRunName()
-        self.assertTrue(isinstance(simname, str))
+        self.assertIsInstance(simname, str)
         self.assertEqual(simname, 'astro-lsst-01_2014')
 
     def testOpsimDbConfig(self):
         """Test generation of config data. """
         configsummary, configdetails = self.oo.fetchConfig()
-        self.assertTrue(isinstance(configsummary, dict))
-        self.assertTrue(isinstance(configdetails, dict))
+        self.assertIsInstance(configsummary, dict)
+        self.assertIsInstance(configdetails, dict)
         #  self.assertEqual(set(configsummary.keys()), set(['Version', 'RunInfo', 'Proposals', 'keyorder']))
         propids, proptags = self.oo.fetchPropInfo()
         propidsSummary = []
@@ -100,8 +100,8 @@ class TestOpsimDb(unittest.TestCase):
         tag = 'WFD'
         sqlWhere = self.oo.createSQLWhere(tag, propTags)
         self.assertEqual(sqlWhere.split()[0], '(proposalId')
-        for id in propTags['WFD']:
-            self.assertTrue('%s' % (id) in sqlWhere)
+        for id_val in propTags['WFD']:
+            self.assertIn('%s' % (id_val), sqlWhere)
         # And the same id can be in multiple proposals.
         tag = 'Rolling'
         sqlWhere = self.oo.createSQLWhere(tag, propTags)

--- a/tests/testOpsimUtils.py
+++ b/tests/testOpsimUtils.py
@@ -12,23 +12,23 @@ class TestOpsimUtils(unittest.TestCase):
         # First test that method returns expected dictionaries.
         for i in ('design', 'stretch'):
             benchmark = opsimUtils.scaleBenchmarks(10.0, i)
-            self.assertTrue(isinstance(benchmark, dict))
+            self.assertIsInstance(benchmark, dict)
             expectedkeys = ('Area', 'nvisitsTotal', 'nvisits', 'seeing', 'skybrightness',
                             'singleVisitDepth')
             expectedfilters = ('u', 'g', 'r', 'i', 'z', 'y')
             for k in expectedkeys:
-                self.assertTrue(k in benchmark)
+                self.assertIn(k, benchmark)
             expecteddictkeys = ('nvisits', 'seeing', 'skybrightness', 'singleVisitDepth')
             for k in expecteddictkeys:
                 for f in expectedfilters:
-                    self.assertTrue(f in benchmark[k])
+                    self.assertIn(f, benchmark[k])
 
     def testCalcCoaddedDepth(self):
         """Test the expected coadded depth calculation."""
         benchmark = opsimUtils.scaleBenchmarks(10, 'design')
         coadd = opsimUtils.calcCoaddedDepth(benchmark['nvisits'], benchmark['singleVisitDepth'])
         for f in coadd:
-            self.assertTrue(coadd[f] < 1000)
+            self.assertLess(coadd[f], 1000)
         singlevisits = {'u': 1, 'g': 1, 'r': 1, 'i': 1, 'z': 1, 'y': 1}
         coadd = opsimUtils.calcCoaddedDepth(singlevisits, benchmark['singleVisitDepth'])
         for f in coadd:

--- a/tests/testResultsDb.py
+++ b/tests/testResultsDb.py
@@ -72,13 +72,13 @@ class TestResultsDb(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             resultsDb.updateSummaryStat(metricId, 'testfail', teststat)
-            self.assertTrue("not save" in str(w[-1].message))
+            self.assertIn("not save", str(w[-1].message))
         # Test get warning when try to add a string (non-conforming) summary stat.
         teststat = 'teststring'
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             resultsDb.updateSummaryStat(metricId, 'testfail', teststat)
-            self.assertTrue("not save" in str(w[-1].message))
+            self.assertIn("not save", str(w[-1].message))
         shutil.rmtree(tempdir)
 
 

--- a/tests/testSimpleMetrics.py
+++ b/tests/testSimpleMetrics.py
@@ -128,6 +128,7 @@ class TestSimpleMetrics(unittest.TestCase):
 
     def testMeanAngleMetric(self):
         """Test mean angle metric."""
+        rng = np.random.RandomState(6573)
         dv1 = np.arange(0, 32, 2.5)
         dv2 = (dv1 - 20.0) % 360.
         dv1 = np.array(list(zip(dv1)), dtype=[('testdata', 'float')])
@@ -136,7 +137,7 @@ class TestSimpleMetrics(unittest.TestCase):
         result1 = testmetric.run(dv1)
         result2 = testmetric.run(dv2)
         self.assertAlmostEqual(result1, (result2+20)%360.)
-        dv = np.random.rand(10000)*360.0
+        dv = rng.rand(10000)*360.0
         dv = dv
         dv = np.array(list(zip(dv)), dtype=[('testdata', 'float')])
         result = testmetric.run(dv)
@@ -145,6 +146,7 @@ class TestSimpleMetrics(unittest.TestCase):
 
     def testFullRangeAngleMetric(self):
         """Test full range angle metric."""
+        rng = np.random.RandomState(5422)
         dv1 = np.arange(0, 32, 2.5)
         dv2 = (dv1 - 20.0) % 360.
         dv1 = np.array(list(zip(dv1)), dtype=[('testdata', 'float')])
@@ -157,7 +159,7 @@ class TestSimpleMetrics(unittest.TestCase):
         dv = np.array(list(zip(dv)), dtype=[('testdata', 'float')])
         result = testmetric.run(dv)
         self.assertAlmostEqual(result, 355)
-        dv = np.random.rand(10000)*360.0
+        dv = rng.rand(10000)*360.0
         dv = np.array(list(zip(dv)), dtype=[('testdata', 'float')])
         result = testmetric.run(dv)
         result = result

--- a/tests/testStackers.py
+++ b/tests/testStackers.py
@@ -26,7 +26,7 @@ class TestStackerClasses(unittest.TestCase):
         # First - are the columns added if they are not there.
         data, cols_present = stacker._addStackerCols(data)
         self.assertEqual(cols_present, False)
-        self.assertTrue(newcol in data.dtype.names)
+        self.assertIn(newcol, data.dtype.names)
         # Next - if they are present, is that information passed back?
         with warnings.catch_warnings():
             warnings.simplefilter('ignore')

--- a/tests/testStackers.py
+++ b/tests/testStackers.py
@@ -230,7 +230,8 @@ class TestStackerClasses(unittest.TestCase):
         odata = np.zeros(len(filt), dtype=list(zip(['filter', 'rotTelPos'], [(np.str_, 1), float])))
         odata['filter'] = filt
         odata['rotTelPos'] = rotTelPos
-        stacker = stackers.RandomRotDitherPerFilterChangeStacker(maxDither=maxDither, degrees=True)
+        stacker = stackers.RandomRotDitherPerFilterChangeStacker(maxDither=maxDither, degrees=True,
+                                                                 randomSeed=99)
         data = stacker.run(odata)
         randomDithers = data['randomDitherPerFilterChangeRotTelPos']
         rotOffsets = rotTelPos - randomDithers
@@ -241,7 +242,8 @@ class TestStackerClasses(unittest.TestCase):
         self.assertTrue(np.all(offsetChanges[:-1] == filtChanges))
         self.assertTrue(np.all(randomDithers <= 90.0))
         stacker = stackers.RandomRotDitherPerFilterChangeStacker(maxDither=maxDither,
-                                                                 degrees=True, maxRotAngle = 30)
+                                                                 degrees=True, maxRotAngle = 30,
+                                                                 randomSeed=19231)
         data = stacker.run(odata)
         randomDithers = data['randomDitherPerFilterChangeRotTelPos']
         self.assertTrue(randomDithers.max(), 30.0)

--- a/tests/testStackers.py
+++ b/tests/testStackers.py
@@ -247,7 +247,7 @@ class TestStackerClasses(unittest.TestCase):
                                                                  randomSeed=19231)
         data = stacker.run(odata)
         randomDithers = data['randomDitherPerFilterChangeRotTelPos']
-        self.assertTrue(randomDithers.max(), 30.0)
+        self.assertEqual(randomDithers.max(), 30.0)
 
     def testHAStacker(self):
         """Test the Hour Angle stacker"""

--- a/tests/testStackers.py
+++ b/tests/testStackers.py
@@ -93,8 +93,8 @@ class TestStackerClasses(unittest.TestCase):
         self.assertGreater(min(np.abs(data['dec_pi_amp'])), 0.)
 
     def _tDitherRange(self, diffsra, diffsdec, ra, dec, maxDither):
-        self.assertTrue(np.all(np.abs(diffsra) <= maxDither))
-        self.assertTrue(np.all(np.abs(diffsdec) <= maxDither))
+        self.assertLessEqual(np.abs(diffsra).max(), maxDither)
+        self.assertLessEqual(np.abs(diffsdec).max(), maxDither)
         offsets = np.sqrt(diffsra**2 + diffsdec**2)
         self.assertLessEqual(offsets.max(), maxDither)
         self.assertGreater(diffsra.max(), 0)

--- a/tests/testStackers.py
+++ b/tests/testStackers.py
@@ -61,10 +61,11 @@ class TestStackerClasses(unittest.TestCase):
         """
         Test the normalized airmass stacker.
         """
+        rng = np.random.RandomState(232)
         data = np.zeros(600, dtype=list(zip(
             ['airmass', 'fieldDec'], [float, float])))
-        data['airmass'] = np.random.rand(600)
-        data['fieldDec'] = np.random.rand(600) * np.pi - np.pi / 2.
+        data['airmass'] = rng.random_sample(600)
+        data['fieldDec'] = rng.random_sample(600) * np.pi - np.pi / 2.
         data['fieldDec'] = np.degrees(data['fieldDec'])
         stacker = stackers.NormAirmassStacker(degrees=True)
         data = stacker.run(data)
@@ -125,11 +126,11 @@ class TestStackerClasses(unittest.TestCase):
         data = np.zeros(600, dtype=list(zip(
             ['fieldRA', 'fieldDec'], [float, float])))
         # Set seed so the test is stable
-        np.random.seed(42)
+        rng = np.random.RandomState(42)
         # Restrict dithers to area where wraparound is not a problem for
         # comparisons.
-        data['fieldRA'] = np.degrees(np.random.rand(600) * (np.pi) + np.pi / 2.0)
-        data['fieldDec'] = np.degrees(np.random.rand(600) * np.pi / 2.0 - np.pi / 4.0)
+        data['fieldRA'] = np.degrees(rng.random_sample(600) * (np.pi) + np.pi / 2.0)
+        data['fieldDec'] = np.degrees(rng.random_sample(600) * np.pi / 2.0 - np.pi / 4.0)
         stacker = stackers.RandomDitherFieldPerVisitStacker(
             maxDither=maxDither)
         data = stacker.run(data)
@@ -147,14 +148,14 @@ class TestStackerClasses(unittest.TestCase):
         maxDither = 0.5
         ndata = 600
         # Set seed so the test is stable
-        np.random.seed(42)
+        rng = np.random.RandomState(42)
 
         data = np.zeros(ndata, dtype=list(zip(
             ['fieldRA', 'fieldDec', 'fieldId', 'night'], [float, float, int, int])))
-        data['fieldRA'] = np.random.rand(ndata) * (np.pi) + np.pi / 2.0
-        data['fieldDec'] = np.random.rand(ndata) * np.pi / 2.0 - np.pi / 4.0
-        data['fieldId'] = np.floor(np.random.rand(ndata) * ndata)
-        data['night'] = np.floor(np.random.rand(ndata) * 10).astype('int')
+        data['fieldRA'] = rng.rand(ndata) * (np.pi) + np.pi / 2.0
+        data['fieldDec'] = rng.rand(ndata) * np.pi / 2.0 - np.pi / 4.0
+        data['fieldId'] = np.floor(rng.rand(ndata) * ndata)
+        data['night'] = np.floor(rng.rand(ndata) * 10).astype('int')
         stacker = stackers.RandomDitherPerNightStacker(maxDither=maxDither)
         data = stacker.run(data)
         diffsra = (np.radians(data['fieldRA']) - np.radians(data['randomDitherPerNightRa'])
@@ -173,16 +174,16 @@ class TestStackerClasses(unittest.TestCase):
         maxDither = 0.5
         ndata = 2000
         # Set seed so the test is stable
-        np.random.seed(42)
+        rng = np.random.RandomState(42)
 
         data = np.zeros(ndata, dtype=list(zip(
             ['fieldRA', 'fieldDec', 'fieldId', 'night'], [float, float, int, int])))
-        data['fieldRA'] = np.random.rand(ndata) * (np.pi) + np.pi / 2.0
+        data['fieldRA'] = rng.rand(ndata) * (np.pi) + np.pi / 2.0
         data['fieldRA'] = np.zeros(ndata) + np.pi / 2.0
-        data['fieldDec'] = np.random.rand(ndata) * np.pi / 2.0 - np.pi / 4.0
+        data['fieldDec'] = rng.rand(ndata) * np.pi / 2.0 - np.pi / 4.0
         data['fieldDec'] = np.zeros(ndata)
-        data['fieldId'] = np.floor(np.random.rand(ndata) * ndata)
-        data['night'] = np.floor(np.random.rand(ndata) * 20).astype('int')
+        data['fieldId'] = np.floor(rng.rand(ndata) * ndata)
+        data['night'] = np.floor(rng.rand(ndata) * 20).astype('int')
         stacker = stackers.SpiralDitherPerNightStacker(maxDither=maxDither)
         data = stacker.run(data)
         diffsra = (data['fieldRA'] - data['spiralDitherPerNightRa']
@@ -201,14 +202,14 @@ class TestStackerClasses(unittest.TestCase):
         maxDither = 0.5
         ndata = 2000
         # Set seed so the test is stable
-        np.random.seed(42)
+        rng = np.random.RandomState(42)
 
         data = np.zeros(ndata, dtype=list(zip(
             ['fieldRA', 'fieldDec', 'fieldId', 'night'], [float, float, int, int])))
-        data['fieldRA'] = np.random.rand(ndata) * (np.pi) + np.pi / 2.0
-        data['fieldDec'] = np.random.rand(ndata) * np.pi / 2.0 - np.pi / 4.0
-        data['fieldId'] = np.floor(np.random.rand(ndata) * ndata)
-        data['night'] = np.floor(np.random.rand(ndata) * 217).astype('int')
+        data['fieldRA'] = rng.rand(ndata) * (np.pi) + np.pi / 2.0
+        data['fieldDec'] = rng.rand(ndata) * np.pi / 2.0 - np.pi / 4.0
+        data['fieldId'] = np.floor(rng.rand(ndata) * ndata)
+        data['night'] = np.floor(rng.rand(ndata) * 217).astype('int')
         stacker = stackers.HexDitherPerNightStacker(maxDither=maxDither)
         data = stacker.run(data)
         diffsra = (data['fieldRA'] - data['hexDitherPerNightRa']
@@ -352,6 +353,7 @@ class TestStackerClasses(unittest.TestCase):
         """
         Test the OpSimFieldStacker
         """
+        rng = np.random.RandomState(812351)
         s = stackers.OpSimFieldStacker(raCol='ra', decCol='dec', degrees=False)
 
         # First sanity check. Make sure the center of the fields returns the right field id
@@ -389,8 +391,8 @@ class TestStackerClasses(unittest.TestCase):
         np.testing.assert_array_equal(field_id, new_data['fieldId'])
 
         # Now let's generate a set of random coordinates and make sure they are all assigned a fieldID.
-        data = np.array(list(zip(np.random.rand(600) * 2. * np.pi,
-                                 np.random.rand(600) * np.pi - np.pi / 2.)),
+        data = np.array(list(zip(rng.rand(600) * 2. * np.pi,
+                                 rng.rand(600) * np.pi - np.pi / 2.)),
                         dtype=list(zip(['ra', 'dec'], [float, float])))
 
         new_data = s.run(data)

--- a/tests/testStackers.py
+++ b/tests/testStackers.py
@@ -397,7 +397,7 @@ class TestStackerClasses(unittest.TestCase):
 
         new_data = s.run(data)
 
-        self.assertTrue(np.all(new_data['fieldId'] > 0))
+        self.assertGreater(new_data['fieldId'].max(), 0)
 
 
 class TestMemory(lsst.utils.tests.MemoryTestCase):

--- a/tests/testStackers.py
+++ b/tests/testStackers.py
@@ -240,8 +240,8 @@ class TestStackerClasses(unittest.TestCase):
         offsetChanges = np.where(rotOffsets[1:] != rotOffsets[:-1])[0]
         filtChanges = np.where(filt[1:] != filt[:-1])[0]
         # Don't count last offset change because this was just value to force min/max limit.
-        self.assertTrue(np.all(offsetChanges[:-1] == filtChanges))
-        self.assertTrue(np.all(randomDithers <= 90.0))
+        np.testing.assert_array_equal(offsetChanges[:-1], filtChanges)
+        self.assertLessEqual(randomDithers.max(), 90.0)
         stacker = stackers.RandomRotDitherPerFilterChangeStacker(maxDither=maxDither,
                                                                  degrees=True, maxRotAngle = 30,
                                                                  randomSeed=19231)

--- a/tests/testTechnicalMetrics.py
+++ b/tests/testTechnicalMetrics.py
@@ -142,8 +142,8 @@ class TestTechnicalMetrics(unittest.TestCase):
                                           'observationStartMJD'])
         metric = metrics.BruteOSFMetric()
         result = metric.run(data)
-        self.assertTrue(result > 0.5)
-        self.assertTrue(result < 0.6)
+        self.assertGreater(result, 0.5)
+        self.assertLess(result, 0.6)
 
     def testCompletenessMetric(self):
         """

--- a/tests/testTrackingDb.py
+++ b/tests/testTrackingDb.py
@@ -66,7 +66,7 @@ class TestTrackingDb(unittest.TestCase):
         # Test removal works.
         trackingdb.delRun(trackId)
         res = tdb.query_arbitrary('select * from runs')
-        self.assertTrue(len(res) == 1)
+        self.assertEqual(len(res), 1)
         # Test cannot remove run which does not exist.
         self.assertRaises(Exception, trackingdb.delRun, trackId)
         trackingdb.close()

--- a/tests/testUniSlicer.py
+++ b/tests/testUniSlicer.py
@@ -9,13 +9,14 @@ from lsst.sims.maf.slicers.oneDSlicer import OneDSlicer
 import lsst.utils.tests
 
 
-def makeDataValues(size=100, min=0., max=1., random=True):
+def makeDataValues(size=100, min=0., max=1., random=-1):
     """Generate a simple array of numbers, evenly arranged between min/max, but (optional) random order."""
     datavalues = np.arange(0, size, dtype='float')
     datavalues *= (float(max) - float(min)) / (datavalues.max() - datavalues.min())
     datavalues += min
-    if random:
-        randorder = np.random.rand(size)
+    if random > 0:
+        rng = np.random.RandomState(random)
+        randorder = rng.rand(size)
         randind = np.argsort(randorder)
         datavalues = datavalues[randind]
     datavalues = np.array(list(zip(datavalues)), dtype=[('testdata', 'float')])
@@ -44,7 +45,7 @@ class TestUniSlicerSetupAndSlice(unittest.TestCase):
         dvmin = 0
         dvmax = 1
         nvalues = 1000
-        dv = makeDataValues(nvalues, dvmin, dvmax, random=True)
+        dv = makeDataValues(nvalues, dvmin, dvmax, random=672)
         self.testslicer.setupSlicer(dv)
         # test slicing
         self.assertEqual(len(self.testslicer.indices), len(dv['testdata']))
@@ -65,7 +66,7 @@ class TestUniSlicerIteration(unittest.TestCase):
         dvmin = 0
         dvmax = 1
         nvalues = 1000
-        dv = makeDataValues(nvalues, dvmin, dvmax, random=True)
+        dv = makeDataValues(nvalues, dvmin, dvmax, random=432)
         self.testslicer.setupSlicer(dv)
         for i, b in enumerate(self.testslicer):
             pass
@@ -76,7 +77,7 @@ class TestUniSlicerIteration(unittest.TestCase):
         dvmin = 0
         dvmax = 1
         nvalues = 1000
-        dv = makeDataValues(nvalues, dvmin, dvmax, random=True)
+        dv = makeDataValues(nvalues, dvmin, dvmax, random=1192)
         self.testslicer.setupSlicer(dv)
         self.assertEqual(self.testslicer[0]['slicePoint']['sid'], 0)
 
@@ -88,7 +89,7 @@ class TestUniSlicerEqual(unittest.TestCase):
         dvmin = 0
         dvmax = 1
         nvalues = 1000
-        dv = makeDataValues(nvalues, dvmin, dvmax, random=True)
+        dv = makeDataValues(nvalues, dvmin, dvmax, random=3482)
         self.testslicer.setupSlicer(dv)
 
     def tearDown(self):
@@ -102,7 +103,7 @@ class TestUniSlicerEqual(unittest.TestCase):
         #  not necessarily the same!).
         # These should be the same, even though data is not the same.
         testslicer2 = UniSlicer()
-        dv2 = makeDataValues(100, 0, 1, random=True)
+        dv2 = makeDataValues(100, 0, 1, random=43298)
         testslicer2.setupSlicer(dv2)
         self.assertEqual(self.testslicer, testslicer2)
         # these will not be the same, as different slicer type.

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -16,9 +16,10 @@ class TestSlicers(unittest.TestCase):
         self.baseslicer = slicers.BaseSlicer()
 
     def test_healpixSlicer_obj(self):
+        rng = np.random.RandomState(8121)
         nside = 32
         slicer = slicers.HealpixSlicer(nside=nside)
-        metricValues = np.random.rand(hp.nside2npix(nside)).astype('object')
+        metricValues = rng.rand(hp.nside2npix(nside)).astype('object')
         metricValues = ma.MaskedArray(data=metricValues,
                                       mask=np.where(metricValues < .1, True, False),
                                       fill_value=slicer.badval)
@@ -34,9 +35,10 @@ class TestSlicers(unittest.TestCase):
                 assert(getattr(slicer, att) == getattr(slicerBack, att))
 
     def test_healpixSlicer_floats(self):
+        rng = np.random.RandomState(71231)
         nside = 32
         slicer = slicers.HealpixSlicer(nside=nside)
-        metricValues = np.random.rand(hp.nside2npix(nside))
+        metricValues = rng.rand(hp.nside2npix(nside))
         with lsst.utils.tests.getTempFilePath('.npz') as filename:
             slicer.writeData(filename, metricValues, metadata='testdata')
             metricValuesBack, slicerBack, header = self.baseslicer.readData(filename)
@@ -47,9 +49,10 @@ class TestSlicers(unittest.TestCase):
                 assert(getattr(slicer, att) == getattr(slicerBack, att))
 
     def test_healpixSlicer_masked(self):
+        rng = np.random.RandomState(712551)
         nside = 32
         slicer = slicers.HealpixSlicer(nside=nside)
-        metricValues = np.random.rand(hp.nside2npix(nside))
+        metricValues = rng.rand(hp.nside2npix(nside))
         metricValues = ma.MaskedArray(data=metricValues,
                                       mask=np.where(metricValues < .1, True, False),
                                       fill_value=slicer.badval)
@@ -63,9 +66,10 @@ class TestSlicers(unittest.TestCase):
                 assert(getattr(slicer, att) == getattr(slicerBack, att))
 
     def test_oneDSlicer(self):
+        rng = np.random.RandomState(71111)
         slicer = slicers.OneDSlicer(sliceColName='testdata')
         dataValues = np.zeros(10000, dtype=[('testdata', 'float')])
-        dataValues['testdata'] = np.random.rand(10000)
+        dataValues['testdata'] = rng.rand(10000)
         slicer.setupSlicer(dataValues)
         with lsst.utils.tests.getTempFilePath('.npz') as filename:
             slicer.writeData(filename, dataValues[:100])
@@ -80,17 +84,18 @@ class TestSlicers(unittest.TestCase):
                     assert(getattr(slicer, att) == getattr(slicerBack, att))
 
     def test_opsimFieldSlicer(self):
+        rng = np.random.RandomState(7442)
         slicer = slicers.OpsimFieldSlicer()
         names = ['fieldRA', 'fieldDec', 'fieldId']
         dt = ['float', 'float', 'int']
-        metricValues = np.random.rand(100)
+        metricValues = rng.rand(100)
         fieldData = np.zeros(100, dtype=list(zip(names, dt)))
-        fieldData['fieldRA'] = np.random.rand(100)
-        fieldData['fieldDec'] = np.random.rand(100)
+        fieldData['fieldRA'] = rng.rand(100)
+        fieldData['fieldDec'] = rng.rand(100)
         fieldData['fieldId'] = np.arange(100)
         names = ['data1', 'data2', 'fieldId']
         simData = np.zeros(100, dtype=list(zip(names, dt)))
-        simData['data1'] = np.random.rand(100)
+        simData['data1'] = rng.rand(100)
         simData['fieldId'] = np.arange(100)
         slicer.setupSlicer(simData, fieldData)
         with lsst.utils.tests.getTempFilePath('.npz') as filename:
@@ -108,9 +113,10 @@ class TestSlicers(unittest.TestCase):
                     assert(getattr(slicer, att) == getattr(slicerBack, att))
 
     def test_unislicer(self):
+        rng = np.random.RandomState(34229)
         slicer = slicers.UniSlicer()
         data = np.zeros(1, dtype=[('testdata', 'float')])
-        data[:] = np.random.rand(1)
+        data[:] = rng.rand(1)
         slicer.setupSlicer(data)
         with lsst.utils.tests.getTempFilePath('.npz') as filename:
             metricValue = np.array([25.])
@@ -124,11 +130,12 @@ class TestSlicers(unittest.TestCase):
 
     def test_complex(self):
         # Test case where there is a complex metric
+        rng = np.random.RandomState(5442)
         nside = 8
         slicer = slicers.HealpixSlicer(nside=nside)
         data = np.zeros(slicer.nslice, dtype='object')
         for i, ack in enumerate(data):
-            n_el = np.random.rand(1)*4  # up to 4 elements
+            n_el = rng.rand(1)*4  # up to 4 elements
             data[i] = np.arange(n_el)
         with lsst.utils.tests.getTempFilePath('.npz') as filename:
             slicer.writeData(filename, data)
@@ -139,10 +146,11 @@ class TestSlicers(unittest.TestCase):
                 np.testing.assert_almost_equal(dataBack[i], data[i])
 
     def test_nDSlicer(self):
+        rng = np.random.RandomState(621)
         colnames = ['test1', 'test2', 'test3']
         data = []
         for c in colnames:
-            data.append(np.random.rand(1000))
+            data.append(rng.rand(1000))
         dv = np.core.records.fromarrays(data, names=colnames)
         slicer = slicers.NDSlicer(colnames, binsList=10)
         slicer.setupSlicer(dv)


### PR DESCRIPTION
This PR just cleans up the unit tests it

1) makes sure that all random number generation is directed through instantiations of `np.random.RandomState` with well-defined seeds

2) replaces `assertTrue` with more specific `assert` methods, except in cases where the assertion is testing the result of an `==` or `!=` operator.

Note: it was not clear to me what the `assertTrue` around lines 102-103 of `testNDSlicer.py` was testing.  If I change it to `assertTrue`, the test fails.  We should either comment or fix that test.