### PR TITLE
U/danielsf/stacker heisen bug

### DIFF
--- a/python/lsst/sims/maf/slicers/orbits.py
+++ b/python/lsst/sims/maf/slicers/orbits.py
@@ -167,9 +167,13 @@ class Orbits(object):
         else:
             raise ValueError('Need either a or q (plus e) in orbit data frame.')
         sedvals = np.empty(len(orbits), dtype=str)
-        if randomSeed is not None:
-            np.random.seed(randomSeed)
-        chance = np.random.random(len(orbits))
+        if not hasattr(self, '_rng'):
+            if randomSeed is not None:
+                self._rng = np.random.RandomState(randomSeed)
+            else:
+                self._rng = np.random.RandomState(334558)
+
+        chance = self._rng.random(len(orbits))
         prob_c = 0.5 * a - 1.0
         # if chance <= prob_c:
         sedvals = np.where(chance <= prob_c, 'C.dat', 'S.dat')

--- a/python/lsst/sims/maf/stackers/ditherStackers.py
+++ b/python/lsst/sims/maf/stackers/ditherStackers.py
@@ -230,8 +230,8 @@ class RandomDitherFieldPerVisitStacker(BaseDitherStacker):
         maxTries = 100
         tries = 0
         while (len(xOut) < noffsets) and (tries < maxTries):
-            dithersRad = np.sqrt(np.random.rand(noffsets * 2)) * self.maxDither
-            dithersTheta = np.random.rand(noffsets * 2) * np.pi * 2.0
+            dithersRad = np.sqrt(self._rng.rand(noffsets * 2)) * self.maxDither
+            dithersTheta = self._rng.rand(noffsets * 2) * np.pi * 2.0
             xOff = dithersRad * np.cos(dithersTheta)
             yOff = dithersRad * np.sin(dithersTheta)
             if self.inHex:
@@ -253,8 +253,12 @@ class RandomDitherFieldPerVisitStacker(BaseDitherStacker):
             # Column already present in data; assume it is correct and does not need recalculating.
             return simData
         # Generate random numbers for dither, using defined seed value if desired.
-        if self.randomSeed is not None:
-            np.random.seed(self.randomSeed)
+        if not hasattr(self, '_rng'):
+            if self.randomSeed is not None:
+                self._rng = np.random.RandomState(self.randomSeed)
+            else:
+                self._rng = np.random.RandomState(2178813)
+
         # Generate the random dither values.
         noffsets = len(simData[self.raCol])
         self._generateRandomOffsets(noffsets)
@@ -331,8 +335,12 @@ class RandomDitherFieldPerNightStacker(RandomDitherFieldPerVisitStacker):
         if cols_present:
             return simData
         # Generate random numbers for dither, using defined seed value if desired.
-        if self.randomSeed is not None:
-            np.random.seed(self.randomSeed)
+        if not hasattr(self, '_rng'):
+            if self.randomSeed is not None:
+                self._rng = np.random.RandomState(self.randomSeed)
+            else:
+                self._rng = np.random.RandomState(872453)
+
         # Generate the random dither values, one per night per field.
         fields = np.unique(simData[self.fieldIdCol])
         nights = np.unique(simData[self.nightCol])
@@ -417,8 +425,12 @@ class RandomDitherPerNightStacker(RandomDitherFieldPerVisitStacker):
         if cols_present:
             return simData
         # Generate random numbers for dither, using defined seed value if desired.
-        if self.randomSeed is not None:
-            np.random.seed(self.randomSeed)
+        if not hasattr(self, '_rng'):
+            if self.randomSeed is not None:
+                self._rng = np.random.RandomState(self.randomSeed)
+            else:
+                self._rng = np.random.RandomState(66334)
+
         # Generate the random dither values, one per night.
         nights = np.unique(simData[self.nightCol])
         self._generateRandomOffsets(len(nights))
@@ -1015,8 +1027,11 @@ class RandomRotDitherPerFilterChangeStacker(BaseDitherStacker):
         if cols_present:
             return simData
         # Generate random numbers for dither, using defined seed value if desired.
-        if self.randomSeed is not None:
-            np.random.seed(self.randomSeed)
+        if not hasattr(self, '_rng'):
+            if self.randomSeed is not None:
+                self._rng = np.random.RandomState(self.randomSeed)
+            else:
+                self._rng = np.random.RandomState(544320)
 
         # Identify points where the filter changes.
         changeIdxs = np.where(simData[self.filterCol][1:] != simData[self.filterCol][:-1])[0]
@@ -1026,7 +1041,7 @@ class RandomRotDitherPerFilterChangeStacker(BaseDitherStacker):
 
         else:
             # Calculate random offsets between +/- self.maxDither  -- in degrees.
-            randomOffsets = np.random.rand(len(changeIdxs)) * 2.0 * self.maxDither - self.maxDither
+            randomOffsets = self._rng.rand(len(changeIdxs)) * 2.0 * self.maxDither - self.maxDither
 
             rotOffset = np.zeros(len(simData), float)
             for i, (c, cn) in enumerate(zip(changeIdxs, changeIdxs[1:])):

--- a/python/lsst/sims/maf/stackers/moStackers.py
+++ b/python/lsst/sims/maf/stackers/moStackers.py
@@ -74,7 +74,13 @@ class MoMagStacker(BaseMoStacker):
         xval = np.power(10, 0.5 * (ssoObs['appMag'] - ssoObs[self.m5Col]))
         ssoObs['SNR'] = 1.0 / np.sqrt((0.04 - self.gamma) * xval + self.gamma * xval * xval)
         completeness = 1.0 / (1 + np.exp((ssoObs['appMag'] - ssoObs[self.m5Col])/self.sigma))
-        probability = np.random.random_sample(len(ssoObs['appMag']))
+        if not hasattr(self, '_rng'):
+            if self.randomSeed is not None:
+                self._rng = np.random.RandomState(self.randomSeed)
+            else:
+                self._rng = np.random.RandomState(734421)
+
+        probability = self._rng.random_sample(len(ssoObs['appMag']))
         ssoObs['vis'] = np.where(probability <= completeness, 1, 0)
         return ssoObs
 

--- a/tests/testStackers.py
+++ b/tests/testStackers.py
@@ -187,8 +187,8 @@ class TestStackerClasses(unittest.TestCase):
         self._tDitherRange(diffsra, diffsdec, data[
                            'fieldRA'], data['fieldDec'], maxDither)
         # Check that dithers on the same night are the same.
-        self._tDitherPerNight(diffsra, diffsdec, data['fieldRA'], data[
-                              'fieldDec'], data['night'])
+        self._tDitherPerNight(diffsra, diffsdec, data['fieldRA'],
+                              data['fieldDec'], data['night'])
 
     def testSpiralDitherPerNight(self):
         """

--- a/tests/testStackers.py
+++ b/tests/testStackers.py
@@ -161,8 +161,8 @@ class TestStackerClasses(unittest.TestCase):
                   * np.cos(np.radians(data['fieldDec']))
         diffsdec = data['fieldDec'] - data['randomDitherFieldPerVisitDec']
         # Check dithers within expected range.
-        self._tDitherRange(diffsra, diffsdec, data[
-                           'fieldRA'], data['fieldDec'], maxDither)
+        self._tDitherRange(diffsra, diffsdec,
+                           data['fieldRA'], data['fieldDec'], maxDither)
 
     def testRandomDitherPerNight(self):
         """
@@ -184,8 +184,8 @@ class TestStackerClasses(unittest.TestCase):
         diffsra = (np.radians(data['fieldRA']) - np.radians(data['randomDitherPerNightRa'])) \
                   * np.cos(np.radians(data['fieldDec']))
         diffsdec = np.radians(data['fieldDec']) - np.radians(data['randomDitherPerNightDec'])
-        self._tDitherRange(diffsra, diffsdec, data[
-                           'fieldRA'], data['fieldDec'], maxDither)
+        self._tDitherRange(diffsra, diffsdec,
+                           data['fieldRA'], data['fieldDec'], maxDither)
         # Check that dithers on the same night are the same.
         self._tDitherPerNight(diffsra, diffsdec, data['fieldRA'],
                               data['fieldDec'], data['night'])
@@ -212,8 +212,8 @@ class TestStackerClasses(unittest.TestCase):
         diffsra = (data['fieldRA'] - data['spiralDitherPerNightRa']) \
                   * np.cos(np.radians(data['fieldDec']))
         diffsdec = data['fieldDec'] - data['spiralDitherPerNightDec']
-        self._tDitherRange(diffsra, diffsdec, data[
-                           'fieldRA'], data['fieldDec'], maxDither)
+        self._tDitherRange(diffsra, diffsdec,
+                           data['fieldRA'], data['fieldDec'], maxDither)
         # Check that dithers on the same night are the same.
         self._tDitherPerNight(diffsra, diffsdec, data['fieldRA'], data[
                               'fieldDec'], data['night'])
@@ -238,8 +238,8 @@ class TestStackerClasses(unittest.TestCase):
         diffsra = (data['fieldRA'] - data['hexDitherPerNightRa']) \
                   * np.cos(np.radians(data['fieldDec']))
         diffsdec = data['fieldDec'] - data['hexDitherPerNightDec']
-        self._tDitherRange(diffsra, diffsdec, data[
-                           'fieldRA'], data['fieldDec'], maxDither)
+        self._tDitherRange(diffsra, diffsdec,
+                           data['fieldRA'], data['fieldDec'], maxDither)
         # Check that dithers on the same night are the same.
         self._tDitherPerNight(diffsra, diffsdec, data['fieldRA'],
                               data['fieldDec'], data['night'])


### PR DESCRIPTION
The use of `np.random.RandomSeed()` to seed random generators was causing an intermittent failure in unit tests.  See the difference between these Jenkins runs, which are ostensibly on the same commit:

this one failed
https://ci.lsst.codes/blue/organizations/jenkins/stack-os-matrix/detail/stack-os-matrix/28510/pipeline

this one passed
https://ci.lsst.codes/blue/organizations/jenkins/stack-os-matrix/detail/stack-os-matrix/28514/pipeline/

Presumably, this failure is due to the fact that test order will affect how the global random state seeds are applied.

I have replaced the global seeding of `np.random` with instance-specific instantiations of `np.random.RandomState`.  That should keep the results of runs reproducible, regardless of the order in which tests are run.