### PR TITLE
Adding WL systematics metric

### DIFF
--- a/python/lsst/sims/maf/metrics/__init__.py
+++ b/python/lsst/sims/maf/metrics/__init__.py
@@ -24,4 +24,4 @@ from .pairMetric import *
 from .nightPointingMetric import *
 from .stringCountMetric import *
 from .areaSummaryMetrics import *
-from .weakLensingSystematicsMetirc import *
+from .weakLensingSystematicsMetric import *

--- a/python/lsst/sims/maf/metrics/__init__.py
+++ b/python/lsst/sims/maf/metrics/__init__.py
@@ -24,3 +24,4 @@ from .pairMetric import *
 from .nightPointingMetric import *
 from .stringCountMetric import *
 from .areaSummaryMetrics import *
+from .weakLensingSystematicsMetirc import *

--- a/python/lsst/sims/maf/metrics/weakLensingSystematicsMetric.py
+++ b/python/lsst/sims/maf/metrics/weakLensingSystematicsMetric.py
@@ -2,9 +2,9 @@ from lsst.sims.maf.metrics import BaseMetric, ExgalM5
 from lsst.sims.maf.maps import DustMap
 
 
-__all__ = ['AverageVisitMetric']
+__all__ = ['NumberOfVisitsMetric']
 
-class AverageVisitsMetric(BaseMetric):
+class NumberOfVisitsMetric(BaseMetric):
     """Note:
         Should be run with the HealpixSlicer. If using dithering (which
         should be the case unless dithering is already implemented in the run)
@@ -16,7 +16,7 @@ class AverageVisitsMetric(BaseMetric):
     def __init__(self,
                  maps,
                  depthlim=24.5,
-                 metricName='AverageVisitsMetric',
+                 metricName='NumberOfVisitsMetric',
                  **kwargs):
         """Weak Lensing systematics metric
 

--- a/python/lsst/sims/maf/metrics/weakLensingSystematicsMetric.py
+++ b/python/lsst/sims/maf/metrics/weakLensingSystematicsMetric.py
@@ -1,140 +1,61 @@
 import numpy as np
-import random
 from .metrics import BaseMetric, ExgalM5
 from .maps import DustMap
 from .slicers import HealpixSlicer
 from lsst.sims.utils import angularSeparation
-import lsst.sims.maf.stackers as stackers
-import lsst.sims.maf.db as db
-import lsst.sims.maf.metricBundles as metricBundles
 
 
-__all__ = ['AverageVisitMetric']
+__all__ = ['NumberOfVisitsMetric']
 
-class AverageVisitsMetric(BaseMetric):
+class NumberOfVisitsMetric(BaseMetric):
 
     
+    
     def __init__(self,
-                 WFDproposalId,
                  runName,
                  maps,
+                 depthlim,
                  Stacker=stackers.RandomDitherFieldPerVisitStacker(
                                         degrees=True),
                  metricName='AverageVisitsMetric',
                  **kwargs):
         """Weak Lensing systematics metric
 
-        Computes the average number of visits per object for 50k objects 
-        uniformly distributed within the WFD, after LSS cuts"""
+        Computes the number of visits per object for a healpix
+        grid of points, within the WFD, after LSS cuts"""
         
         super(AverageVisitsMetric, self).__init__(
-            metricName=metricName, col=['fieldId', 'fieldDec'],
+            metricName=metricName, col=['fieldId', 'fieldDec', 'fiveSigmaDepth'],
             maps=maps, **kwargs
             )
-        self.WFDproposalId = WFDproposalId
         self.FOVradius = 1.75
-        self.star_num = 5000
-        self.counter = {}
-        self.positions = []
         self.runName = runName
         self.Stacker = Stacker
-        self.stars = self.getPositions(self.runName, self.WFDproposalId)
-        self.slice = []
+        self.ExgalM5 = ExgalM5()
+        self.depthlim = depthlim
 
     def run(self, dataSlice, slicePoint=None):
-    """runs the metric
+        """runs the metric
 
-    Args:
-        dataSlice (namedArrat): positional data from querying the database
-        slicePoint (namedArray): queried data along with data from stackers
-    Returns:
-        None
-    """
+        Args:
+            dataSlice (ndarray): positional data from querying the database
+            slicePoint (dict): queried data along with data from stackers
+        Returns:
+            (int): total number of visits at this healpix point
+        """
+        result = 0
+        if slicePoint['ebv'] > 0.2:
+            return self.badval
+        ExgalM5 = self.ExgalM5.run(dataSlice=dataSlice, slicePoint=slicePoint)
+        if ExgalM5 < self.depthlim:
+            return self.badval
+        for datum in dataSlice:
+            if angularSeparation(
+                datum[3],
+                datum[4],
+                slicePoint['ra']*np.degrees(1),
+                slicePoint['dec']*np.degrees(1)
+                ) < self.FOVradius:
+                result += 1
+        return result
 
-        for data in dataSlice:
-            posRA = data[2]
-            posDec = data[3]
-
-            pos = np.array((posRA, posDec))
-            self.positions.append(pos)
-
-        return
-
-    def getPositions(self, runName, WFDproposalId):
-    """runs ExgalM5 metric to get a random sample of stars
-    within the low-extinction, high-depth area.
-
-    Args:
-        runName (str): name (and path) of operational simulation.
-                       without any extension
-        WFDproposalId (int): ID corresponding to the wide-fast-deep
-                             main survey in the database
-
-    Returns:
-        ndarray: position of stars
-    """
-        
-        opsdb = db.OpsimDatabase(runName+'.db')
-        outDir = 'temp'
-        resultsDb = db.ResultsDb(outDir=outDir)
-        nside = 256
-        sqlconstraint = 'filter = "i" and proposalId = ' + WFDproposalId
-
-        metric = ExgalM5(lsstFilter='i')
-        dustMap = DustMap(interp=False, nside=nside)
-        slicer = HealpixSlicer(nside=nside, useCache=False)
-
-        mBundle = {'temp': metricBundles.MetricBundle(
-            metric, 
-            slicer, 
-            constraint=sqlconstraint,
-            stackerList=[], 
-            runName=runName,
-            metadata='temp to get positions', 
-            mapsList=[dustMap])}
-        
-        bgroup = metricBundles.MetricBundleGroup(mBundle,
-                                                 opsdb,
-                                                 outDir=outDir,
-                                                 resultsDb=resultsDb)
-        bgroup.runAll()
-        bundle = mBundle['temp']
-        cond = np.logical_and.reduce(
-            (bundle.slicer.getSlicePoints()['ebv'] < 0.2,
-             bundle.metricValues.mask == False,
-             bundle.metricValues.data > 26)
-        )
-        condx = (bundle.slicer.getSlicePoints()['ra'])[cond]
-        condy = (bundle.slicer.getSlicePoints()['dec'])[cond]
-        centers = [np.array([xi, yi]) for xi, yi in zip(condx, condy)]
-
-        
-        return np.array(
-            random.sample(centers*100, self.star_num)
-            ) + np.random.normal(0, 0.009, (self.star_num, 2))
-
-    def reduceAvgExp(self, _):
-    """calculates the number of times each object is observed and returns the mean
-
-    Args:
-        None
-
-    Returns:
-        float: average number of i-band exposures per object
-    """
-        self.positions = np.array(self.positions)
-        for position_num in range(len(self.stars)):
-            star_pos = self.stars[position_num]
-            
-            cond = angularSeparation(
-                self.positions[:, 0],
-                self.positions[:, 1],
-                star_pos[0]*np.degrees(1),
-                star_pos[1]*np.degrees(1)
-                ) < self.FOVradius
-    
-            if tuple(star_pos) in self.counter.keys():
-                self.counter[tuple(star_pos)] += len(self.positions[cond])
-            else:
-                self.counter[tuple(star_pos)] = len(self.positions[cond])
-        return np.mean(list(self.counter.values()))

--- a/python/lsst/sims/maf/metrics/weakLensingSystematicsMetric.py
+++ b/python/lsst/sims/maf/metrics/weakLensingSystematicsMetric.py
@@ -17,12 +17,13 @@ class WeakLensingNvisits(BaseMetric):
     def __init__(self,
                  maps,
                  depthlim=24.5,
+                 ebvlim=0.2,
                  metricName='WeakLensingNvisits',
                  **kwargs):
         """Weak Lensing systematics metric
 
         Computes the average number of visits per point on a HEALPix grid
-        after E(B-V) and co-added depth cuts.
+        after a maximum E(B-V) cut and a minimum co-added depth cut.
         """
         
         super().__init__(
@@ -33,6 +34,7 @@ class WeakLensingNvisits(BaseMetric):
             )
         self.ExgalM5 = ExgalM5()
         self.depthlim = depthlim
+        self.ebvlim = ebvlim
 
     def run(self, dataSlice, slicePoint=None):
         """runs the metric
@@ -43,7 +45,7 @@ class WeakLensingNvisits(BaseMetric):
         Returns:
             the number of visits that can observe this healpix point.
         """
-        if slicePoint['ebv'] > 0.2:
+        if slicePoint['ebv'] > self.ebvlim:
             return self.badval
         ExgalM5 = self.ExgalM5.run(dataSlice=dataSlice, slicePoint=slicePoint)
         if ExgalM5 < self.depthlim:

--- a/python/lsst/sims/maf/metrics/weakLensingSystematicsMetric.py
+++ b/python/lsst/sims/maf/metrics/weakLensingSystematicsMetric.py
@@ -1,5 +1,6 @@
-from lsst.sims.maf.metrics import BaseMetric, ExgalM5
-from lsst.sims.maf.maps import DustMap
+from .baseMetric import BaseMetric
+from .exgalM5 import ExgalM5
+from ..maps import DustMap
 
 
 __all__ = ['NumberOfVisitsMetric']

--- a/python/lsst/sims/maf/metrics/weakLensingSystematicsMetric.py
+++ b/python/lsst/sims/maf/metrics/weakLensingSystematicsMetric.py
@@ -1,0 +1,140 @@
+import numpy as np
+import random
+from .metrics import BaseMetric, ExgalM5
+from .maps import DustMap
+from .slicers import HealpixSlicer
+from lsst.sims.utils import angularSeparation
+import lsst.sims.maf.stackers as stackers
+import lsst.sims.maf.db as db
+import lsst.sims.maf.metricBundles as metricBundles
+
+
+__all__ = ['AverageVisitMetric']
+
+class AverageVisitsMetric(BaseMetric):
+
+    
+    def __init__(self,
+                 WFDproposalId,
+                 runName,
+                 maps,
+                 Stacker=stackers.RandomDitherFieldPerVisitStacker(
+                                        degrees=True),
+                 metricName='AverageVisitsMetric',
+                 **kwargs):
+        """Weak Lensing systematics metric
+
+        Computes the average number of visits per object for 50k objects 
+        uniformly distributed within the WFD, after LSS cuts"""
+        
+        super(AverageVisitsMetric, self).__init__(
+            metricName=metricName, col=['fieldId', 'fieldDec'],
+            maps=maps, **kwargs
+            )
+        self.WFDproposalId = WFDproposalId
+        self.FOVradius = 1.75
+        self.star_num = 5000
+        self.counter = {}
+        self.positions = []
+        self.runName = runName
+        self.Stacker = Stacker
+        self.stars = self.getPositions(self.runName, self.WFDproposalId)
+        self.slice = []
+
+    def run(self, dataSlice, slicePoint=None):
+    """runs the metric
+
+    Args:
+        dataSlice (namedArrat): positional data from querying the database
+        slicePoint (namedArray): queried data along with data from stackers
+    Returns:
+        None
+    """
+
+        for data in dataSlice:
+            posRA = data[2]
+            posDec = data[3]
+
+            pos = np.array((posRA, posDec))
+            self.positions.append(pos)
+
+        return
+
+    def getPositions(self, runName, WFDproposalId):
+    """runs ExgalM5 metric to get a random sample of stars
+    within the low-extinction, high-depth area.
+
+    Args:
+        runName (str): name (and path) of operational simulation.
+                       without any extension
+        WFDproposalId (int): ID corresponding to the wide-fast-deep
+                             main survey in the database
+
+    Returns:
+        ndarray: position of stars
+    """
+        
+        opsdb = db.OpsimDatabase(runName+'.db')
+        outDir = 'temp'
+        resultsDb = db.ResultsDb(outDir=outDir)
+        nside = 256
+        sqlconstraint = 'filter = "i" and proposalId = ' + WFDproposalId
+
+        metric = ExgalM5(lsstFilter='i')
+        dustMap = DustMap(interp=False, nside=nside)
+        slicer = HealpixSlicer(nside=nside, useCache=False)
+
+        mBundle = {'temp': metricBundles.MetricBundle(
+            metric, 
+            slicer, 
+            constraint=sqlconstraint,
+            stackerList=[], 
+            runName=runName,
+            metadata='temp to get positions', 
+            mapsList=[dustMap])}
+        
+        bgroup = metricBundles.MetricBundleGroup(mBundle,
+                                                 opsdb,
+                                                 outDir=outDir,
+                                                 resultsDb=resultsDb)
+        bgroup.runAll()
+        bundle = mBundle['temp']
+        cond = np.logical_and.reduce(
+            (bundle.slicer.getSlicePoints()['ebv'] < 0.2,
+             bundle.metricValues.mask == False,
+             bundle.metricValues.data > 26)
+        )
+        condx = (bundle.slicer.getSlicePoints()['ra'])[cond]
+        condy = (bundle.slicer.getSlicePoints()['dec'])[cond]
+        centers = [np.array([xi, yi]) for xi, yi in zip(condx, condy)]
+
+        
+        return np.array(
+            random.sample(centers*100, self.star_num)
+            ) + np.random.normal(0, 0.009, (self.star_num, 2))
+
+    def reduceAvgExp(self, _):
+    """calculates the number of times each object is observed and returns the mean
+
+    Args:
+        None
+
+    Returns:
+        float: average number of i-band exposures per object
+    """
+        self.positions = np.array(self.positions)
+        for position_num in range(len(self.stars)):
+            star_pos = self.stars[position_num]
+            
+            cond = angularSeparation(
+                self.positions[:, 0],
+                self.positions[:, 1],
+                star_pos[0]*np.degrees(1),
+                star_pos[1]*np.degrees(1)
+                ) < self.FOVradius
+    
+            if tuple(star_pos) in self.counter.keys():
+                self.counter[tuple(star_pos)] += len(self.positions[cond])
+            else:
+                self.counter[tuple(star_pos)] = len(self.positions[cond])
+        return np.mean(list(self.counter.values()))

--- a/python/lsst/sims/maf/metrics/weakLensingSystematicsMetric.py
+++ b/python/lsst/sims/maf/metrics/weakLensingSystematicsMetric.py
@@ -3,9 +3,9 @@ from .exgalM5 import ExgalM5
 from ..maps import DustMap
 
 
-__all__ = ['NumberOfVisitsMetric']
+__all__ = ['WeakLensingNvisits']
 
-class NumberOfVisitsMetric(BaseMetric):
+class WeakLensingNvisits(BaseMetric):
     """Note:
         Should be run with the HealpixSlicer. If using dithering (which
         should be the case unless dithering is already implemented in the run)
@@ -17,7 +17,7 @@ class NumberOfVisitsMetric(BaseMetric):
     def __init__(self,
                  maps,
                  depthlim=24.5,
-                 metricName='NumberOfVisitsMetric',
+                 metricName='WeakLensingNvisits',
                  **kwargs):
         """Weak Lensing systematics metric
 
@@ -27,7 +27,7 @@ class NumberOfVisitsMetric(BaseMetric):
         
         super().__init__(
             metricName=metricName, 
-            col=['fieldId', 'fieldDec', 'fiveSigmaDepth'],
+            col=['fiveSigmaDepth'],
             maps=maps, 
             **kwargs
             )


### PR DESCRIPTION

This is _not_ yet ready to be merged but I am starting this PR while I finish developing it and in the meantime hoping to get feedback.

**overview** 
The metric is designed to calculate the number of average i-band, WFD visits for a set of 50k objects

First it runs the ExgalM5 metric with a dust map to get a sample of objects, randomly-drawn from a uniform (equal-area in healpix) distribution within the WL-usable area (low-extinction, above a certain depth, etc)

Then the run method simply assembles a list of all the telescope dither positions (centers of FOV) 

Finally the reduce method is supposed to calculate the number of times each object is observed, and then return the average.

**issues**
The metric is running much, much slower than it runs when executing the code directly (i.e. not calling the metric from within MAF). Essentially, the result of the metric should be a single number (the average number of visits), but it seems that the reduce method is being ran for each single visit. Is this the case? If so, is there a better way for me to do this in MAF (something other than reduce methods?), where something is only ran once in the end and returns a single number for the whole metric?

Thank you!