### PR TITLE
Fix bug where thumbnail name mangled if '.' in plotname

### DIFF
--- a/python/lsst/sims/maf/db/resultsDb.py
+++ b/python/lsst/sims/maf/db/resultsDb.py
@@ -387,7 +387,8 @@ class ResultsDb(object):
             query = (self.session.query(MetricRow, PlotRow).filter(MetricRow.metricId == mid)
                      .filter(MetricRow.metricId == PlotRow.metricId))
             for m, p in query:
-                thumbfile = 'thumb.' + ''.join(p.plotFile.split('.')[:-1]) + '.png'
+                # The plotFile typically ends with .pdf (but the rest of name can have '.' or '_')
+                thumbfile = 'thumb.' + '.'.join(p.plotFile.split('.')[:-1]) + '.png'
                 plotFiles.append((m.metricId, m.metricName, m.metricMetadata,
                                   p.plotType, p.plotFile, thumbfile))
         # Convert to numpy array.


### PR DESCRIPTION
runnames like "baseline_v1.3_10yrs" results in the thumbnail names (generated by the ResultsDb class) being mangled. 
This PR fixes that problem so we can see thumbnails again [or at least .. this was a  problem for the moving object plots .. for some reason, the standard plots had already substituted "_" for "."]. 
