### PR TITLE
adding figure of merit metric

### DIFF
--- a/python/lsst/sims/maf/metrics/exgalM5.py
+++ b/python/lsst/sims/maf/metrics/exgalM5.py
@@ -2,7 +2,7 @@ from .baseMetric import BaseMetric
 from .simpleMetrics import Coaddm5Metric
 from lsst.sims.photUtils import Sed
 
-__all__ = ['ExgalM5']
+__all__ = ['ExgalM5', 'ExgalM5_cut']
 
 class ExgalM5(BaseMetric):
     """
@@ -57,3 +57,78 @@ class ExgalM5(BaseMetric):
         A_x = (self.a[0]+self.b[0]/self.R_v)*(self.R_v*slicePoint['ebv'])
         result = m5-A_x
         return result
+
+    
+class ExgalM5_cut(BaseMetric):
+    """
+    Calculate co-added five-sigma limiting depth after dust extinction 
+    and depth cuts
+
+    A copy of ExgalM5 for use of FoMEmulator as a Summary Metric on this.
+    """
+    def __init__(self, m5Col='fiveSigmaDepth', units='mag',
+                 lsstFilter='i', wavelen_min=None, wavelen_max=None, 
+                 wavelen_step=1., extinction_cut=0.2, depth_cut=26, **kwargs):
+        """
+        Args: 
+            m5Col (str): Column name that ('fiveSigmaDepth')
+            units (str): units of the metric ('mag')
+            lsstFilter (str): Which LSST filter to calculate m5 for
+            wavelen_min (float): Minimum wavength of your filter (None)
+            wavelen_max (float): (None)
+            wavelen_step (float): (1.)
+            **kwargs:
+        """
+        maps = ['DustMap']
+        waveMins={'u':330., 'g':403., 'r':552., 'i':691., 'z':818., 'y':950.}
+        waveMaxes={'u':403., 'g':552., 'r':691., 'i':818., 'z':922., 'y':1070.}
+
+        if lsstFilter is not None:
+            wavelen_min = waveMins[lsstFilter]
+            wavelen_max = waveMaxes[lsstFilter]
+
+        self.m5Col = m5Col
+        super(ExgalM5_cut, self).__init__(col=[self.m5Col],
+                                          maps=maps, 
+                                          units=units, 
+                                          **kwargs
+                                         )
+
+        testsed = Sed()
+        testsed.setFlatSED(wavelen_min=wavelen_min,
+                           wavelen_max=wavelen_max, 
+                           wavelen_step=1)
+        self.a,self.b = testsed.setupCCM_ab()
+        self.R_v = 3.1
+        self.Coaddm5Metric = Coaddm5Metric(m5Col=m5Col)
+        
+        self.extinction_cut = extinction_cut
+        self.depth_cut = depth_cut
+
+
+    def run(self, dataSlice, slicePoint=None):
+        """
+        Compute the co-added m5 depth and then apply extinction cut
+        and depth cut to that magnitude.
+            
+        Args:
+            dataSlice (ndarray): Values passed to metric by the slicer, 
+                which the metric will use to calculate metric values 
+                at each slicePoint.
+            slicePoint (Dict): Dictionary of slicePoint metadata passed
+                to each metric.
+        Returns:
+             float: the dust atennuated co-added m5-depth.
+        """
+        
+        if slicePoint['ebv'] > self.extinction_cut:
+            return self.badval
+
+        m5 = self.Coaddm5Metric.run(dataSlice)
+        A_x = (self.a[0] + self.b[0]/self.R_v) * (self.R_v*slicePoint['ebv'])
+        result = m5-A_x
+        if result < self.depth_cut:
+            return self.badval
+        else:
+            return result
+

--- a/python/lsst/sims/maf/metrics/summaryMetrics.py
+++ b/python/lsst/sims/maf/metrics/summaryMetrics.py
@@ -229,7 +229,11 @@ class TotalPowerMetric(BaseMetric):
 
 
 
-class FoMEmulatorMetric(BaseMetric):
+class StaticProbesFoMEmulatorMetric(BaseMetric):
+    """This calculates the Figure of Merit for the combined
+    static probes (3x2pt, i.e., Weak Lensing, LSS, Clustering).
+    This FoM is purely statistical and does not factor in systematics.
+    """
     def __init__(self, nside=128, year=10, col=None, **kwargs):
         
         """

--- a/python/lsst/sims/maf/metrics/weakLensingSystematicsMetric.py
+++ b/python/lsst/sims/maf/metrics/weakLensingSystematicsMetric.py
@@ -6,7 +6,10 @@ from ..maps import DustMap
 __all__ = ['WeakLensingNvisits']
 
 class WeakLensingNvisits(BaseMetric):
-    """Note:
+    """A proxy metric for WL systematics. Higher value indicated better 
+    systematics mitigation.
+    
+    Note:
         Should be run with the HealpixSlicer. If using dithering (which
         should be the case unless dithering is already implemented in the run)
         then should be run with a stacker and appropriate column names for 


### PR DESCRIPTION
Adding the static-probe statistical figure of merit emulator metric, to easily replicate what was used in the DESC observing strategy whitepaper on new sims. This can be run as a summary metric. It requires a version of ExgalM5 that has ebv and depth cuts so adding that as well.  Thanks to @yoachim  for help with writing this.

Example code to run this metric (suppressing imports to declutter)
```py
outDir = 'temp'
resultsDb = db.ResultsDb(outDir=outDir)
dbFile = '/global/cscratch1/sd/awan/dbs_post_wp_v2/add_mag_clouds_v1.3_10yrs.db'
conn = db.OpsimDatabase(dbFile)
sql = 'filter = "i" and note not like "DD%"'
metric = ExgalM5_cut(depth_cut=26)
slicer = slicers.HealpixSlicer(nside=nside, useCache=False)
summary = [FoMEmulatorMetric()]
bundleList = [metricBundles.MetricBundle(metric, slicer, sql, summaryMetrics=summary)]
bd = metricBundles.makeBundlesDictFromList(bundleList)
bg = metricBundles.MetricBundleGroup(bd, conn, outDir=outDir, resultsDb=resultsDb)
bg.runAll()

# result: 
(bg.bundleDict['opsim_ExgalM5_cut_fiveSigmaDepth_i_and_note_not_like_DD%_HEAL']).summaryValues

```

