### PR TITLE
Add new metric info results for runComparison when you don't plot

### DIFF
--- a/python/lsst/sims/maf/runComparison/runComparison.py
+++ b/python/lsst/sims/maf/runComparison/runComparison.py
@@ -227,7 +227,7 @@ class RunComparison(object):
                                                                       metricMetadataLike=metricMetadataLike,
                                                                       slicerNameLike=slicerNameLike)
                 for mId in mIds:
-                    info = self.runresults[r][subdir].getMetricDisplayInfo(mId)
+                    info = self.runresults[r][subdir].getMetricInfo(mId)
                     metricName = info['metricName'][0]
                     metricMetadata = info['metricMetadata'][0]
                     slicerName = info['slicerName'][0]
@@ -253,7 +253,7 @@ class RunComparison(object):
         return name
 
     def _findSummaryStats(self, metricName, metricMetadata=None, slicerName=None, summaryName=None,
-                          colName=None):
+                          colName=None, verbose=False):
         """
         Look for summary metric values matching metricName (and optionally metricMetadata, slicerName
         and summaryName) among the results databases for each run.
@@ -271,6 +271,9 @@ class RunComparison(object):
         colName : str, opt
             Name of the column header for the dataframe. If more than one summary stat is
             returned from the database, then this will be ignored.
+        verbose : bool, opt
+            Issue warnings resulting from not finding the summary stat information
+            (such as if it was never calculated) will not be issued.   Default False.
 
         Results
         -------
@@ -303,7 +306,7 @@ class RunComparison(object):
                                                           stats['summaryName'][i])
                             summaryValues[r][name] = stats['summaryValue'][i]
                             summaryNames[r][name] = stats['summaryName'][i]
-            if len(summaryValues[r]) == 0:
+            if len(summaryValues[r]) == 0 and verbose:
                 warnings.warn("Warning: Found no metric results for %s %s %s %s in run %s"
                               % (metricName, metricMetadata, slicerName, summaryName, r))
         # Make DataFrame.
@@ -343,7 +346,7 @@ class RunComparison(object):
         stats = pd.concat(tempDFList)
         return header, stats
 
-    def addSummaryStats(self, metricDict):
+    def addSummaryStats(self, metricDict, verbose=False):
         """
         Combine the summary statistics of a set of metrics into a pandas
         dataframe that is indexed by the opsim run name.
@@ -354,6 +357,9 @@ class RunComparison(object):
             A dictionary of metrics with all of the information needed to query
             a results database.  The metric/metadata/slicer/summary values referred to
             by a metricDict value could be unique but don't have to be.
+        verbose : bool, opt
+            Issue warnings resulting from not finding the summary stat information
+            (such as if it was never calculated) will not be issued.   Default False.
 
         Returns
         -------
@@ -373,7 +379,7 @@ class RunComparison(object):
                                                                metricMetadata=metric['metricMetadata'],
                                                                slicerName=metric['slicerName'],
                                                                summaryName=metric['summaryName'],
-                                                               colName=mName)
+                                                               colName=mName, verbose=verbose)
             if self.summaryStats is None:
                 self.summaryStats = tempStats
                 self.headerStats = tempHeader

--- a/python/lsst/sims/maf/runComparison/runComparison.py
+++ b/python/lsst/sims/maf/runComparison/runComparison.py
@@ -346,17 +346,19 @@ class RunComparison(object):
         stats = pd.concat(tempDFList)
         return header, stats
 
-    def addSummaryStats(self, metricDict, verbose=False):
+    def addSummaryStats(self, metricDict=None, verbose=False):
         """
         Combine the summary statistics of a set of metrics into a pandas
         dataframe that is indexed by the opsim run name.
 
         Parameters
         ----------
-        metricDict: dict
+        metricDict: dict, opt
             A dictionary of metrics with all of the information needed to query
             a results database.  The metric/metadata/slicer/summary values referred to
             by a metricDict value could be unique but don't have to be.
+            If None (default), then fetches all metric results.
+            (This can be slow if there are a lot of metrics.)
         verbose : bool, opt
             Issue warnings resulting from not finding the summary stat information
             (such as if it was never calculated) will not be issued.   Default False.
@@ -372,6 +374,8 @@ class RunComparison(object):
             <run_123>    <metricValue1>  <metricValue2>
             <run_124>    <metricValue1>  <metricValue2>
         """
+        if metricDict is None:
+            metricDict = self.buildMetricDict()
         for mName, metric in metricDict.items():
             if 'summaryName' not in metric:
                 metric['summaryName'] = None


### PR DESCRIPTION
The runcomparison class was using a method for getting metric information that included a query against the display info (which was then not used). However, display info is only saved when metrics are plotted or summary stats calculated .. which was not the (direct) case for SSO metrics. So instead, I added a simple 'metric info' class to resultsDb to avoid those failures and am using that instead to get the metric information.
I also added a flag to suppress the warnings that were being issued when summary metrics were not found. 
I hope these changes make your changes to the addSummaryStats easier .. OH wait, I'll just add the other extra thing you did (which was if mDict was None to addSummaryStats, it defaulted to getting everything). 