### PR TITLE
runCurrent now automatically runs setCurrent.

### DIFF
--- a/python/lsst/sims/maf/metricBundles/metricBundleGroup.py
+++ b/python/lsst/sims/maf/metricBundles/metricBundleGroup.py
@@ -239,7 +239,6 @@ class MetricBundleGroup(object):
         for constraint in self.constraints:
             # Set the 'currentBundleDict' which is a dictionary of the metricBundles which match this
             #  constraint.
-            self.setCurrent(constraint)
             self.runCurrent(constraint, clearMemory=clearMemory,
                             plotNow=plotNow, plotKwargs=plotKwargs)
 
@@ -281,6 +280,8 @@ class MetricBundleGroup(object):
         plotKwargs : kwargs, opt
            Plotting kwargs to pass to plotCurrent.
         """
+        self.setCurrent(constraint)
+
         # Build list of all the columns needed from the database.
         self.dbCols = []
         for b in self.currentBundleDict.values():


### PR DESCRIPTION
Make runCurrent (which runs a set of metric bundles with the same sqlconstraint) automatically select the subset of bundles which match the constraint. Previously you had to run 'setCurrent' as a separate, prior, step. Now they run together.
However, I left 'setCurrent' as a separate method, as it is potentially called elsewhere (such as when plotting a subset of bundles). 